### PR TITLE
docs: v0.25 dapi endpoint example updates

### DIFF
--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -19,11 +19,11 @@ Some [additional metadata](https://github.com/dashevo/platform/blob/master/packa
 
 ### broadcastStateTransition
 
-> 📘 
-> 
+> 📘
+>
 > **Note:** The [`waitForStateTransitionResult` endpoint](#waitforstatetransitionresult) should be used in conjunction with this one for instances where proof of block confirmation is required.
 
-Broadcasts a [state transition](../explanations/platform-protocol-state-transition.md) to the platform via DAPI to make a change to layer 2 data. The `broadcastStateTransition` call returns once the state transition has been accepted into the mempool. 
+Broadcasts a [state transition](../explanations/platform-protocol-state-transition.md) to the platform via DAPI to make a change to layer 2 data. The `broadcastStateTransition` call returns once the state transition has been accepted into the mempool.
 
 **Returns**: Nothing or error
 
@@ -49,7 +49,7 @@ Broadcasts a [state transition](../explanations/platform-protocol-state-transiti
 
 > 🚧 Breaking changes
 >
-> As of Dash Platform 0.24 the `protocolVersion` is no longer included in the CBOR-encoded data. It is instead prepended as a varint to the data following CBOR encoding.
+> Due to serialization changes in Dash Platform 0.25, using wasm-dpp is recommended when working with identities, data contracts, and documents.
 
 **Returns**: [Identity](../explanations/identity.md) information for the requested identity  
 **Parameters**:
@@ -339,6 +339,10 @@ grpcurl -proto protos/platform/v0/platform.proto \
 
 ### getDataContract
 
+> 🚧 Breaking changes
+>
+> Due to serialization changes in Dash Platform 0.25, using wasm-dpp is recommended when working with identities, data contracts, and documents.
+
 **Returns**: [Data Contract](../explanations/platform-protocol-data-contract.md) information for the requested data contract  
 **Parameters**:
 
@@ -347,11 +351,11 @@ grpcurl -proto protos/platform/v0/platform.proto \
 | `id`    | Bytes   | Yes      | A data contract `id`                                                       |
 | `prove` | Boolean | No       | Set to `true` to receive a proof that contains the requested data contract |
 
-> 📘 
-> 
+> 📘
+>
 > **Note**: When requesting proofs, the data requested will be encoded as part of the proof in the response.
 
-** Example Request and Response **
+**Example Request and Response**
 
 ::::{tab-set-code}
 
@@ -375,6 +379,7 @@ client.platform.getDataContract(contractId).then((response) => {
   });
 });
 ```
+
 ```javascript JavaScript (dapi-grpc)
 // JavaScript (dapi-grpc)
 const {
@@ -400,6 +405,7 @@ platformPromiseClient
   })
   .catch((e) => console.error(e));
 ```
+
 ```shell gRPCurl
 # gRPCurl
 # `id` must be represented in base64
@@ -562,6 +568,7 @@ grpcurl -proto protos/platform/v0/platform.proto \
   }
 }
 ```
+
 ```json Response (gRPCurl)
 // Response (gRPCurl)
 {
@@ -579,13 +586,17 @@ grpcurl -proto protos/platform/v0/platform.proto \
 
 ### getDocuments
 
+> 🚧 Breaking changes
+>
+> Due to serialization changes in Dash Platform 0.25, using wasm-dpp is recommended when working with identities, data contracts, and documents.
+
 **Returns**: [Document](../explanations/platform-protocol-document.md) information for the requested document(s)  
 **Parameters**:
 
-> 🚧 - Parameter constraints
-> 
-> The `where`, `order_by`, `limit`, `start_at`, and `start_after` parameters must comply with the limits defined on the [Query Syntax](../reference/query-syntax.md) page.
-> 
+> 📘 Parameter constraints
+>
+> **Note**: The `where`, `order_by`, `limit`, `start_at`, and `start_after` parameters must comply with the limits defined on the [Query Syntax](../reference/query-syntax.md) page.
+>
 > Additionally, note that `where` and `order_by` must be [CBOR](https://tools.ietf.org/html/rfc7049) encoded.
 
 | Name                    | Type    | Required | Description                                                                                      |
@@ -602,11 +613,11 @@ grpcurl -proto protos/platform/v0/platform.proto \
 | ----------              |         |          |                                                                                                  |
 | `prove`                 | Boolean | No       | Set to `true` to receive a proof that contains the requested document(s)                         |
 
-> 📘 
-> 
+> 📘
+>
 > **Note**: When requesting proofs, the data requested will be encoded as part of the proof in the response.
 
-** Example Request and Response **
+**Example Request and Response**
 
 ::::{tab-set-code}
 
@@ -648,6 +659,7 @@ client.platform.getDataContract(contractId).then((contractResponse) => {
     });
 });
 ```
+
 ```javascript JavaScript (dapi-grpc)
 // JavaScript (dapi-grpc)
 const {
@@ -698,6 +710,7 @@ platformPromiseClient
   })
   .catch((e) => console.error(e));
 ```
+
 ```shell Request (gRPCurl)
 # gRPCurl
 # Request documents
@@ -754,6 +767,7 @@ grpcurl -proto protos/platform/v0/platform.proto \
   "$type": "domain"
 }
 ```
+
 ```json Response (gRPCurl)
 // Response (gRPCurl)
 {
@@ -781,11 +795,11 @@ grpcurl -proto protos/platform/v0/platform.proto \
 | `state_transition_hash` | Bytes   | Yes      | Hash of the state transition     |
 | `prove`                 | Boolean | Yes      | Set to `true` to request a proof |
 
-> 📘 
-> 
+> 📘
+>
 > **Note**: When requesting proofs, the data requested will be encoded as part of the proof in the response.
 
-** Example Request**
+**Example Request**
 
 ```{eval-rst}
 ..
@@ -813,6 +827,7 @@ client.platform.waitForStateTransitionResult(hash, { prove: true })
   });
 
 ```
+
 ```shell Request (gRPCurl)
 # gRPCurl
 # Replace `your_state_transition_hash` with your own before running
@@ -847,5 +862,5 @@ No endpoints were deprecated in Dash Platform v0.24, but the previous version of
 
 Implementation details related to the information on this page can be found in:
 
-- The [Platform repository](https://github.com/dashevo/platform/tree/master/packages/dapi) `packages/dapi/lib/grpcServer/handlers/core` folder
-- The [Platform repository](https://github.com/dashevo/platform/tree/master/packages/dapi-grpc) `packages/dapi-grpc/protos` folder
+* The [Platform repository](https://github.com/dashevo/platform/tree/master/packages/dapi) `packages/dapi/lib/grpcServer/handlers/core` folder
+* The [Platform repository](https://github.com/dashevo/platform/tree/master/packages/dapi-grpc) `packages/dapi-grpc/protos` folder

--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -48,7 +48,7 @@ Broadcasts a [state transition](../explanations/platform-protocol-state-transiti
 ### getIdentity
 
 > 🚧 Breaking changes
-> 
+>
 > As of Dash Platform 0.24 the `protocolVersion` is no longer included in the CBOR-encoded data. It is instead prepended as a varint to the data following CBOR encoding.
 
 **Returns**: [Identity](../explanations/identity.md) information for the requested identity  
@@ -59,11 +59,11 @@ Broadcasts a [state transition](../explanations/platform-protocol-state-transiti
 | `id`    | Bytes   | Yes      | An identity `id`                                                      |
 | `prove` | Boolean | No       | Set to `true` to receive a proof that contains the requested identity |
 
-> 📘 
-> 
+> 📘
+>
 > **Note**: When requesting proofs, the data requested will be encoded as part of the proof in the response.
 
-** Example Request and Response **
+**Example Request and Response**
 
 ::::{tab-set-code}
 
@@ -86,6 +86,7 @@ client.platform.getIdentity(identityId).then((response) => {
   console.log(identity.toJSON());
 });
 ```
+
 ```javascript JavaScript (dapi-grpc)
 // JavaScript (dapi-grpc)
 const {
@@ -117,6 +118,7 @@ platformPromiseClient
   })
   .catch((e) => console.error(e));
 ```
+
 ```shell gRPCurl
 # gRPCurl
 # `id` must be represented in base64
@@ -165,6 +167,7 @@ grpcurl -proto protos/platform/v0/platform.proto \
   "revision": 0
 }
 ```
+
 ```json Response (gRPCurl)
 // Response (gRPCurl)
 {
@@ -182,7 +185,7 @@ grpcurl -proto protos/platform/v0/platform.proto \
 
 ### getIdentitiesByPublicKeyHashes
 
-**Returns**: [Identity](../explanations/identity.md) an array of identities associated with the provided public key hashes  
+**Returns**: An array of [identities](../explanations/identity.md) associated with the provided public key hashes  
 **Parameters**:
 
 | Name                | Type    | Required | Description                                                             |
@@ -190,28 +193,31 @@ grpcurl -proto protos/platform/v0/platform.proto \
 | `public_key_hashes` | Bytes   | Yes      | Public key hashes (sha256-ripemd160) of identity public keys            |
 | `prove`             | Boolean | No       | Set to `true` to receive a proof that contains the requested identities |
 
-> 📘 
-> 
+> 📘
+>
 > **Note**: When requesting proofs, the data requested will be encoded as part of the proof in the response.
 
 > 📘 Public key hash
-> 
+>
 > Note: the hash must be done using all fields of the identity public key object - e.g.
-> 
+>
 > ```json
 > {
+>   "$version": "0",
 >   "id": 0,
->   "type": 0,
 >   "purpose": 0,
 >   "securityLevel": 0,
->   "data": "A2GTAJk9eAWkMXVCb+rRKXH99POtR5OaW6zqZl7/yozp",
->   "readOnly": false
+>   "contractBounds": null,
+>   "type": 0,
+>   "readOnly": false,
+>   "data": "Asi0dHtSjKxf3femzGNwLuBO19EzKQTghRA0PqANzlRq",
+>   "disabledAt": null
 > }
 > ```
-> 
+>
 > When using the js-dpp library, the hash can be accessed via the [IdentityPublicKey object's](https://github.com/dashevo/platform/blob/master/packages/js-dpp/lib/identity/IdentityPublicKey.js) `hash` method (e.g. `identity.getPublicKeyById(0).hash()`).
 
-** Example Request and Response **
+**Example Request and Response**
 
 ::::{tab-set-code}
 
@@ -235,6 +241,7 @@ client.platform.getIdentitiesByPublicKeyHashes(publicKeysBuffer)
     console.log(retrievedIdentity.toJSON());
   });
 ```
+
 ```javascript JavaScript (dapi-grpc)
 // JavaScript (dapi-grpc)
 const {

--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -247,30 +247,30 @@ client.platform.getIdentitiesByPublicKeyHashes(publicKeysBuffer)
 const {
   v0: { PlatformPromiseClient, GetIdentitiesByPublicKeyHashesRequest },
 } = require('@dashevo/dapi-grpc');
-const DashPlatformProtocol = require('@dashevo/dpp');
+const { DashPlatformProtocol, default: loadDpp } = require('@dashevo/wasm-dpp');
 
+loadDpp();
 const dpp = new DashPlatformProtocol();
 
-dpp.initialize()
-  .then(() => {
-    const platformPromiseClient = new PlatformPromiseClient(
-      'https://seed-1.testnet.networks.dash.org:1443',
-    );
+const platformPromiseClient = new PlatformPromiseClient(
+  'https://seed-1.testnet.networks.dash.org:1443',
+);
 
-    const publicKeyHash = 'b8d1591aa74d440e0af9c0be16c55bbc141847f7';
-    const publicKeysBuffer = [Buffer.from(publicKeyHash, 'hex')];
+const publicKeyHash = 'b8d1591aa74d440e0af9c0be16c55bbc141847f7';
+const publicKeysBuffer = [Buffer.from(publicKeyHash, 'hex')];
 
-    const getIdentitiesByPublicKeyHashesRequest = new GetIdentitiesByPublicKeyHashesRequest();
-    getIdentitiesByPublicKeyHashesRequest.setPublicKeyHashesList(publicKeysBuffer);
+const getIdentitiesByPublicKeyHashesRequest = new GetIdentitiesByPublicKeyHashesRequest();
+getIdentitiesByPublicKeyHashesRequest.setPublicKeyHashesList(publicKeysBuffer);
 
-    platformPromiseClient.getIdentitiesByPublicKeyHashes(getIdentitiesByPublicKeyHashesRequest)
-      .then((response) => {
-        const identitiesResponse = response.getIdentitiesList();
-      	console.log(dpp.identity.createFromBuffer(Buffer.from(identitiesResponse[0])).toJSON());
-      })
-      .catch((e) => console.error(e));
-  	});
+platformPromiseClient
+  .getIdentitiesByPublicKeyHashes(getIdentitiesByPublicKeyHashesRequest)
+  .then((response) => {
+    const identitiesResponse = response.getIdentities().getIdentitiesList();
+    console.log(dpp.identity.createFromBuffer(Buffer.from(identitiesResponse[0])).toJSON());
+  })
+  .catch((e) => console.error(e));
 ```
+
 ```shell gRPCurl
 # gRPCurl
 # `public_key_hashes` must be represented in base64
@@ -315,10 +315,11 @@ grpcurl -proto protos/platform/v0/platform.proto \
       "disabledAt": null
     }
   ],
-  "balance": 2344694260,
+  "balance": 7327280900,
   "revision": 0
 }
 ```
+
 ```json Response (gRPCurl)
 // Response (gRPCurl)
 {

--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -70,21 +70,20 @@ Broadcasts a [state transition](../explanations/platform-protocol-state-transiti
 ```javascript JavaScript (dapi-client)
 // JavaScript (dapi-client)
 const DAPIClient = require('@dashevo/dapi-client');
-const Identifier = require('@dashevo/dpp/lib/Identifier');
-const cbor = require('cbor');
-const varint = require('varint');
+const {
+  default: loadDpp,
+  DashPlatformProtocol,
+  Identifier,
+} = require('@dashevo/wasm-dpp');
 
+loadDpp();
+const dpp = new DashPlatformProtocol();
 const client = new DAPIClient();
 
 const identityId = Identifier.from('4EfA9Jrvv3nnCFdSf7fad59851iiTRZ6Wcu6YVJ4iSeF');
 client.platform.getIdentity(identityId).then((response) => {
-  // Strip off protocol version (leading varint) and decode
-  const identityBuffer = Buffer.from(response.getIdentity());
-  const protocolVersion = varint.decode(identityBuffer);
-  const identity = cbor.decode(
-    identityBuffer.slice(varint.encodingLength(protocolVersion), identityBuffer.length),
-  );
-  console.log(identity);
+  const identity = dpp.identity.createFromBuffer(response.getIdentity());
+  console.log(identity.toJSON());
 });
 ```
 ```javascript JavaScript (dapi-grpc)
@@ -92,10 +91,14 @@ client.platform.getIdentity(identityId).then((response) => {
 const {
   v0: { PlatformPromiseClient, GetIdentityRequest },
 } = require('@dashevo/dapi-grpc');
-const Identifier = require('@dashevo/dpp/lib/Identifier');
-const cbor = require('cbor');
-const varint = require('varint');
+const {
+  default: loadDpp,
+  DashPlatformProtocol,
+  Identifier,
+} = require('@dashevo/wasm-dpp');
 
+loadDpp();
+const dpp = new DashPlatformProtocol(null);
 const platformPromiseClient = new PlatformPromiseClient(
   'https://seed-1.testnet.networks.dash.org:1443',
 );
@@ -106,15 +109,11 @@ const getIdentityRequest = new GetIdentityRequest();
 getIdentityRequest.setId(idBuffer);
 getIdentityRequest.setProve(false);
 
-platformPromiseClient.getIdentity(getIdentityRequest)
+platformPromiseClient
+  .getIdentity(getIdentityRequest)
   .then((response) => {
-    // Strip off protocol version (leading varint) and decode
-    const identityBuffer = Buffer.from(response.getIdentity());
-    const protocolVersion = varint.decode(identityBuffer);
-    const decodedIdentity = cbor.decode(
-      identityBuffer.slice(varint.encodingLength(protocolVersion), identityBuffer.length),
-    );
-    console.log(decodedIdentity);  
+    const identity = dpp.identity.createFromBuffer(response.getIdentity());
+    console.dir(identity.toJSON());
   })
   .catch((e) => console.error(e));
 ```
@@ -136,27 +135,34 @@ grpcurl -proto protos/platform/v0/platform.proto \
 ```json Response (JavaScript)
 // Response (JavaScript)
 {
-  "id": "<Buffer 30 12 c1 9b 98 ec 00 33 ad db 36 cd 64 b7 f5 10 67 0f 2a 35 1a 43 04 b5 f6 99 41 44 28 6e fd ac>",
-  "balance": 5255234422,
-  "revision": 0,
+  "$version": "0",
+  "id": "4EfA9Jrvv3nnCFdSf7fad59851iiTRZ6Wcu6YVJ4iSeF",
   "publicKeys": [
     {
+      "$version": "0",
       "id": 0,
-      "data": "<Buffer 02 c8 b4 74 7b 52 8c ac 5f dd f7 a6 cc 63 70 2e e0 4e d7 d1 33 29 04 e0 85 10 34 3e a0 0d ce 54 6a>",
-      "type": 0,
       "purpose": 0,
+      "securityLevel": 0,
+      "contractBounds": null,
+      "type": 0,
       "readOnly": false,
-      "securityLevel": 0
+      "data": "Asi0dHtSjKxf3femzGNwLuBO19EzKQTghRA0PqANzlRq",
+      "disabledAt": null
     },
     {
+      "$version": "0",
       "id": 1,
-      "data": "<Buffer 02 01 ee 28 f8 4f 54 85 39 05 67 e9 39 c2 b5 86 01 0b 63 a6 9e c9 2c ab 53 5d c9 6a 8c 71 91 36 02>",
-      "type": 0,
       "purpose": 0,
+      "securityLevel": 2,
+      "contractBounds": null,
+      "type": 0,
       "readOnly": false,
-      "securityLevel": 2
+      "data": "AgHuKPhPVIU5BWfpOcK1hgELY6aeySyrU13JaoxxkTYC",
+      "disabledAt": null
     }
-  ]
+  ],
+  "balance": 7327280900,
+  "revision": 0
 }
 ```
 ```json Response (gRPCurl)


### PR DESCRIPTION
Updates example dapi-client and dapi-grpc code. Now more reliant on DPP to handle deserializing platform objects.

<!-- Replace -->
Preview build: https://dash-docs-platform--26.org.readthedocs.build/en/26/
<!-- Replace -->
