### PR TITLE
docs(reference): add getDataContractHistory info

### DIFF
--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -368,7 +368,7 @@ const {
   Identifier,
 } = require('@dashevo/wasm-dpp');
 
-  loadDpp();
+loadDpp();
 const dpp = new DashPlatformProtocol(null);
 const client = new DAPIClient();
 

--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -584,6 +584,95 @@ grpcurl -proto protos/platform/v0/platform.proto \
 
 ::::
 
+### getDataContractHistory
+
+**Returns**: [Data Contract](../explanations/platform-protocol-data-contract.md) information for the requested data contract  
+**Parameters**:
+
+| Name    | Type     | Required | Description                              |
+| ------- | -------- | -------- | ---------------------------------------- |
+| `id`    | Bytes    | Yes      | A data contract `id`                     |
+| `start_at_ms` | Integer | Yes | Request revisions starting at this timestamp |
+| `limit` | Integer  | Yes      | The maximum number of revisions to return |
+| `offset` | Integer | Yes      | The offset of the first revision to return |
+| `prove` | Boolean  | No       | Set to `true` to receive a proof that contains the requested data contract |
+
+> 📘
+>
+> **Note**: When requesting proofs, the data requested will be encoded as part of the proof in the response.
+
+**Example Request and Response**
+
+::::{tab-set-code}
+
+```javascript JavaScript (dapi-client)
+// JavaScript (dapi-client)
+const DAPIClient = require('@dashevo/dapi-client');
+const {
+  default: loadDpp,
+  DashPlatformProtocol,
+  Identifier,
+} = require('@dashevo/wasm-dpp');
+
+loadDpp();
+const dpp = new DashPlatformProtocol(null);
+const client = new DAPIClient();
+
+const contractId = Identifier.from('Fq6p2uvoS1JRCnvLCV3DwjLDCzAjHJqsKP53c8k3ipoH');
+client.platform.getDataContractHistory(contractId, 0, 1, 0).then((response) => {
+  for (const key in response.getDataContractHistory()) {
+    const revision = response.getDataContractHistory()[key];
+    dpp.dataContract.createFromBuffer(revision).then((dataContract) => {
+      console.dir(dataContract.toJSON(), { depth: 10 });
+    });
+  }
+});
+```
+
+```shell gRPCurl
+# gRPCurl
+# `id` must be represented in base64
+grpcurl -proto protos/platform/v0/platform.proto \
+  -d '{
+    "id":"5mjGWa9mruHnLBht3ntbfgodcSoJxA1XIfYiv1PFMVU=",
+    "limit": 1,
+    "offset": 0,
+    "start_at_ms": 0,
+    "prove": false    
+    }' \
+  seed-1.testnet.networks.dash.org:1443 \
+  org.dash.platform.dapi.v0.Platform/getDataContractHistory
+```
+
+::::
+
+::::{tab-set-code}
+
+```json Response (JavaScript)
+// Response (JavaScript)
+[
+
+]
+```
+
+```json Response (gRPCurl)
+// Response (gRPCurl)
+{
+  "dataContractHistory": {
+    
+  },
+  "metadata": {
+    "height": "1056",
+    "coreChainLockedHeight": 922820,
+    "timeMs": "1697125325434",
+    "protocolVersion": 1,
+    "chainId": "devnet"
+  }
+}
+```
+
+::::
+
 ### getDocuments
 
 > 🚧 Breaking changes

--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -649,18 +649,10 @@ grpcurl -proto protos/platform/v0/platform.proto \
 
 ::::{tab-set-code}
 
-```json Response (JavaScript)
-// Response (JavaScript)
-[
-
-]
-```
-
 ```json Response (gRPCurl)
 // Response (gRPCurl)
 {
   "dataContractHistory": {
-    
   },
   "metadata": {
     "height": "1056",
@@ -670,6 +662,10 @@ grpcurl -proto protos/platform/v0/platform.proto \
     "chainId": "devnet"
   }
 }
+```
+
+```json Response (JavaScript)
+// Response (JavaScript)
 ```
 
 ::::

--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -619,8 +619,8 @@ loadDpp();
 const dpp = new DashPlatformProtocol(null);
 const client = new DAPIClient();
 
-const contractId = Identifier.from('Fq6p2uvoS1JRCnvLCV3DwjLDCzAjHJqsKP53c8k3ipoH');
-client.platform.getDataContractHistory(contractId, 0, 1, 0).then((response) => {
+const contractId = Identifier.from('BWgzcW4XRhmYKzup1xY8fMi3ZHGG1Hf8fD9Rm3e3bopm');
+client.platform.getDataContractHistory(contractId, 0, 2, 0).then((response) => {
   for (const key in response.getDataContractHistory()) {
     const revision = response.getDataContractHistory()[key];
     dpp.dataContract.createFromBuffer(revision).then((dataContract) => {
@@ -636,7 +636,7 @@ client.platform.getDataContractHistory(contractId, 0, 1, 0).then((response) => {
 grpcurl -proto protos/platform/v0/platform.proto \
   -d '{
     "id":"5mjGWa9mruHnLBht3ntbfgodcSoJxA1XIfYiv1PFMVU=",
-    "limit": 1,
+    "limit": 2,
     "offset": 0,
     "start_at_ms": 0,
     "prove": false    
@@ -648,6 +648,69 @@ grpcurl -proto protos/platform/v0/platform.proto \
 ::::
 
 ::::{tab-set-code}
+
+```json Response (JavaScript)
+// Response (JavaScript)
+{
+  "$format_version": "0",
+  "id": "BWgzcW4XRhmYKzup1xY8fMi3ZHGG1Hf8fD9Rm3e3bopm",
+  "config": {
+    "$format_version": "0",
+    "canBeDeleted": false,
+    "readonly": false,
+    "keepsHistory": true,
+    "documentsKeepHistoryContractDefault": false,
+    "documentsMutableContractDefault": true,
+    "requiresIdentityEncryptionBoundedKey": null,
+    "requiresIdentityDecryptionBoundedKey": null
+  },
+  "version": 1,
+  "ownerId": "DKFKmJ58ZTDddvviDJwDyCznDMxd9Y6bsJcBN5Xp8m5w",
+  "schemaDefs": null,
+  "documentSchemas": {
+    "note": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+},
+{
+  "$format_version": "0",
+  "id": "BWgzcW4XRhmYKzup1xY8fMi3ZHGG1Hf8fD9Rm3e3bopm",
+  "config": {
+    "$format_version": "0",
+    "canBeDeleted": false,
+    "readonly": false,
+    "keepsHistory": true,
+    "documentsKeepHistoryContractDefault": false,
+    "documentsMutableContractDefault": true,
+    "requiresIdentityEncryptionBoundedKey": null,
+    "requiresIdentityDecryptionBoundedKey": null
+  },
+  "version": 2,
+  "ownerId": "DKFKmJ58ZTDddvviDJwDyCznDMxd9Y6bsJcBN5Xp8m5w",
+  "schemaDefs": null,
+  "documentSchemas": {
+    "note": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}
+```
 
 ```json Response (gRPCurl)
 // Response (gRPCurl)
@@ -662,10 +725,6 @@ grpcurl -proto protos/platform/v0/platform.proto \
     "chainId": "devnet"
   }
 }
-```
-
-```json Response (JavaScript)
-// Response (JavaScript)
 ```
 
 ::::

--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -6,7 +6,7 @@ Please refer to the [gRPC Overview](../reference/dapi-endpoints-grpc-overview.md
 
 Since Dash Platform 0.20.0, Platform gRPC endpoints can provide [proofs](https://github.com/dashpay/platform/blob/master/packages/dapi-grpc/protos/platform/v0/platform.proto#L17-L22) so the data returned for a request can be verified as being valid. Full support is not yet available in the JavaScript client, but can be used via the low level [dapi-grpc library](https://github.com/dashevo/platform/tree/master/packages/dapi-grpc).
 
-Some [additional metadata](https://github.com/dashevo/platform/blob/master/packages/dapi-grpc/protos/platform/v0/platform.proto#L30-L33) is also provided with responses:
+Some [additional metadata](https://github.com/dashevo/platform/blob/master/packages/dapi-grpc/protos/platform/v0/platform.proto#L38-L44) is also provided with responses:
 
 | Metadata field          | Description                                           |
 | :---------------------- | :---------------------------------------------------- |
@@ -14,6 +14,7 @@ Some [additional metadata](https://github.com/dashevo/platform/blob/master/packa
 | `coreChainLockedHeight` | Height of the most recent ChainLock on the core chain |
 | `timeMs`                | Unix timestamp in milliseconds for the response       |
 | `protocolVersion`       | Platform protocol version                             |
+| `chainId`               | Name of the network                                   |
 
 ## Endpoint Details
 

--- a/docs/reference/dapi-endpoints.md
+++ b/docs/reference/dapi-endpoints.md
@@ -8,24 +8,24 @@
 
 ## JSON-RPC Endpoints
 
-| Layer | Endpoint                                                                           | Description                                                |
-| :---: | ---------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-|   1   | [`getBestBlockHash`](../reference/dapi-endpoints-json-rpc-endpoints.md#getbestblockhash) | Returns block hash of the chaintip                         |
-|   1   | [`getBlockHash`](../reference/dapi-endpoints-json-rpc-endpoints.md#getblockhash)         | Returns block hash of the requested block                  |
+| Layer | Endpoint | Description |
+| :---: | -------- | ----------- |
+|   1   | [`getBestBlockHash`](../reference/dapi-endpoints-json-rpc-endpoints.md#getbestblockhash) | Returns block hash of the chaintip |
+|   1   | [`getBlockHash`](../reference/dapi-endpoints-json-rpc-endpoints.md#getblockhash)         | Returns block hash of the requested block |
 |   1   | [`getMnListDiff`](../reference/dapi-endpoints-json-rpc-endpoints.md#getmnlistdiff)       | Returns masternode list diff for the provided block hashes |
 
 ## gRPC Endpoints
 
 ### Core gRPC Service
 
-| Layer | Endpoint                                                                                                                         |                                                                                                                                                                                                                                                                                           |
-| :---: | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|   1   | [`broadcastTransaction`](../reference/dapi-endpoints-core-grpc-endpoints.md#broadcasttransaction)                                      | Broadcasts the provided transaction                                                                                                                                                                                                                                                       |
-|   1   | [`getBlock`](../reference/dapi-endpoints-core-grpc-endpoints.md#getblock)                                                              | Returns information for the requested block                                                                                                                                                                                                                                               |
-|   1   | [`getStatus`](../reference/dapi-endpoints-core-grpc-endpoints.md#getstatus)                                                            | Returns blockchain status information                                                                                                                                                                                                                                                     |
-|   1   | [`getTransaction`](../reference/dapi-endpoints-core-grpc-endpoints.md#gettransaction)                                                  | Returns details for the requested transaction                                                                                                                                                                                                                                             |
-|   1   | [`subscribeTo` `BlockHeadersWithChainLocks`](../reference/dapi-endpoints-core-grpc-endpoints.md#subscribetoblockheaderswithchainlocks) | Returns the requested block headers along with the associated ChainLocks.<br>_Added in Dash Platform v0.22_                                                                                                                                                                               |
-|   1   | [`subscribeTo` `TransactionsWithProofs`](../reference/dapi-endpoints-core-grpc-endpoints.md#subscribetotransactionswithproofs)         | Returns transactions matching the provided bloom filter along with the associated [`islock` message](https://docs.dash.org/projects/core/en/stable/docs/reference/p2p-network-instantsend-messages.html#islock) and [merkle block](https://docs.dash.org/projects/core/en/stable/docs/reference/p2p-network-data-messages.html#merkleblock) |
+| Layer | Endpoint |   |
+| :---: | -------- | - |
+|   1   | [`broadcastTransaction`](../reference/dapi-endpoints-core-grpc-endpoints.md#broadcasttransaction) | Broadcasts the provided transaction |
+|   1   | [`getBlock`](../reference/dapi-endpoints-core-grpc-endpoints.md#getblock) | Returns information for the requested block |
+|   1   | [`getStatus`](../reference/dapi-endpoints-core-grpc-endpoints.md#getstatus) | Returns blockchain status information |
+|   1   | [`getTransaction`](../reference/dapi-endpoints-core-grpc-endpoints.md#gettransaction) | Returns details for the requested transaction |
+|   1   | [`subscribeTo` `BlockHeadersWithChainLocks`](../reference/dapi-endpoints-core-grpc-endpoints.md#subscribetoblockheaderswithchainlocks) | Returns the requested block headers along with the associated ChainLocks.<br>_Added in Dash Platform v0.22_ |
+|   1   | [`subscribeTo` `TransactionsWithProofs`](../reference/dapi-endpoints-core-grpc-endpoints.md#subscribetotransactionswithproofs) | Returns transactions matching the provided bloom filter along with the associated [`islock` message](https://docs.dash.org/projects/core/en/stable/docs/reference/p2p-network-instantsend-messages.html#islock) and [merkle block](https://docs.dash.org/projects/core/en/stable/docs/reference/p2p-network-data-messages.html#merkleblock) |
 
 ### Platform gRPC Service
 
@@ -51,8 +51,8 @@ In addition to providing the request data, the following endpoints can also prov
   [/block]
 ```
 
-> 📘 
-> 
+> 📘
+>
 > The previous version of documentation can be [viewed here](https://docs.dash.org/projects/platform/en/0.24.0/docs/reference/dapi-endpoints.html).
 
 ```{toctree}

--- a/docs/reference/dapi-endpoints.md
+++ b/docs/reference/dapi-endpoints.md
@@ -31,15 +31,15 @@
 
 In addition to providing the request data, the following endpoints can also provide proofs that the data returned is valid and complete.
 
-| Layer | Endpoint                                                                                                       |                                                                                                                           |
-| :---: | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-|   2   | [`broadcastStateTransition`](../reference/dapi-endpoints-platform-endpoints.md#broadcaststatetransition)             | Broadcasts the provided State Transition                                                                                  |
-|   2   | [`getIdentity`](../reference/dapi-endpoints-platform-endpoints.md#getidentity)                                       | Returns the requested identity                                                                                            |
-|   2   | [`getIdentitiesByPublicKeyHashes`](../reference/dapi-endpoints-platform-endpoints.md#getidentitiesbypublickeyhashes) | Returns the identities associated with the provided public key hashes<br>_Added in Dash Platform v0.16_                   |
-|   2   | [`getDataContract`](../reference/dapi-endpoints-platform-endpoints.md#getdatacontract)                               | Returns the requested data contract                                                                                       |
-|   2   | [`getDocuments`](../reference/dapi-endpoints-platform-endpoints.md#getdocuments)                                     | Returns the requested document(s)                                                                                         |
+| Layer | Endpoint |   |
+| :---: | -------- | - |
+|   2   | [`broadcastStateTransition`](../reference/dapi-endpoints-platform-endpoints.md#broadcaststatetransition)             | Broadcasts the provided State Transition |
+|   2   | [`getIdentity`](../reference/dapi-endpoints-platform-endpoints.md#getidentity)                                       | Returns the requested identity |
+|   2   | [`getIdentitiesByPublicKeyHashes`](../reference/dapi-endpoints-platform-endpoints.md#getidentitiesbypublickeyhashes) | Returns the identities associated with the provided public key hashes<br>_Added in Dash Platform v0.16_ |
+|   2   | [`getDataContract`](../reference/dapi-endpoints-platform-endpoints.md#getdatacontract)                               | Returns the requested data contract |
+|   2   | [`getDataContractHistory`](../reference/dapi-endpoints-platform-endpoints.md#getdatacontracthistory)                 | Returns the requested data contract history |
+|   2   | [`getDocuments`](../reference/dapi-endpoints-platform-endpoints.md#getdocuments)                                     | Returns the requested document(s) |
 |   2   | [`waitForStateTransitionResult`](../reference/dapi-endpoints-platform-endpoints.md#waitforstatetransitionresult)     | Responds with the state transition hash and either a proof that the state transition was confirmed in a block or an error |
-
 
 ```{eval-rst}
 ..

--- a/docs/reference/dapi-endpoints.md
+++ b/docs/reference/dapi-endpoints.md
@@ -4,7 +4,10 @@
 
 # DAPI Endpoints
 
-[DAPI](../explanations/dapi.md) currently provides 2 types of endpoints: [JSON-RPC](https://www.jsonrpc.org/) and [gRPC](https://grpc.io/docs/guides/). The JSON-RPC endpoints expose some layer 1 information while the gRPC endpoints support layer 2 as well as streaming of events related to blocks and transactions/transitions.
+[DAPI](../explanations/dapi.md) currently provides 2 types of endpoints:
+[JSON-RPC](https://www.jsonrpc.org/) and [gRPC](https://grpc.io/docs/guides/). The JSON-RPC
+endpoints expose some layer 1 information while the gRPC endpoints support layer 2 as well as
+streaming of events related to blocks and transactions/transitions.
 
 ## JSON-RPC Endpoints
 
@@ -29,7 +32,8 @@
 
 ### Platform gRPC Service
 
-In addition to providing the request data, the following endpoints can also provide proofs that the data returned is valid and complete.
+In addition to providing the request data, the following endpoints can also provide proofs that the
+data returned is valid and complete.
 
 | Layer | Endpoint |   |
 | :---: | -------- | - |
@@ -53,7 +57,8 @@ In addition to providing the request data, the following endpoints can also prov
 
 > 📘
 >
-> The previous version of documentation can be [viewed here](https://docs.dash.org/projects/platform/en/0.24.0/docs/reference/dapi-endpoints.html).
+> The previous version of documentation can be [viewed
+> here](https://docs.dash.org/projects/platform/en/0.24.0/docs/reference/dapi-endpoints.html).
 
 ```{toctree}
 :maxdepth: 2


### PR DESCRIPTION
Adds the new `getDataContractHistory` endpoint from Dash Platform v0.25

<!-- Replace -->
Preview build: https://dash-docs-platform--31.org.readthedocs.build/en/31/
<!-- Replace -->
