### PR TITLE
chore: bump Node.JS requirements to v20 (current LTS)

### DIFF
--- a/docs/tutorials/connecting-to-testnet.md
+++ b/docs/tutorials/connecting-to-testnet.md
@@ -8,7 +8,7 @@ Platform services are provided via a combination of HTTP and gRPC connections to
 
 ## Prerequisites
 
-- An installation of [NodeJS v18 or higher](https://nodejs.org/en/download/)
+- An installation of [NodeJS v20 or higher](https://nodejs.org/en/download/)
 
 ## Connect via Dash SDK
 

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -16,7 +16,7 @@ Building on Dash Platform requires first registering an Identity and then regist
 
 The tutorials in this section are written in JavaScript and use [Node.js](https://nodejs.org/en/about/). The following prerequisites are necessary to complete the tutorials:
 
-- [Node.js](https://nodejs.org/en/) (v18+)
+- [Node.js](https://nodejs.org/en/) (v20+)
 - Familiarity with JavaScript asynchronous functions using [async/await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await)
 - The Dash JavaScript SDK (see [Connecting to a Network](../tutorials/connecting-to-testnet.md#1-install-the-dash-sdk))
 

--- a/docs/tutorials/node-setup/connect-to-a-network-dash-masternode.md
+++ b/docs/tutorials/node-setup/connect-to-a-network-dash-masternode.md
@@ -4,7 +4,7 @@ The purpose of this tutorial is to walk through the steps necessary to set up a 
 
 ## Prerequisites
 - [Docker](https://docs.docker.com/engine/install/) (v20.10.0+) and [docker-compose](https://docs.docker.com/compose/install/) (v1.25.0+) installed
-- An installation of [NodeJS](https://nodejs.org/en/download/) (v18, NPM v8.0+)
+- An installation of [NodeJS](https://nodejs.org/en/download/) (v20, NPM v8.0+)
 
 The following is not necessary for setting up a local network for development, but is helpful if setting up a testnet masternode:
 - Access to a Linux system configured with a non-root user ([guide](https://docs.dash.org/en/stable/masternodes/setup.html#set-up-your-vps))


### PR DESCRIPTION
Bump minimum Node.JS version as we drop support of outdated Node.js versions

<!-- Replace -->
Preview build: https://dash-docs-platform--34.org.readthedocs.build/en/34/
<!-- Replace -->
