### PR TITLE
docs: update contract register and update

### DIFF
--- a/docs/explanations/platform-protocol-data-contract.md
+++ b/docs/explanations/platform-protocol-data-contract.md
@@ -90,29 +90,34 @@ An example contract for [DashPay](https://github.com/dashevo/platform/blob/maste
       "avatarUrl": {
         "type": "string",
         "format": "uri",
-        "maxLength": 2048
+        "maxLength": 2048,
+        "position": 0
       },
       "avatarHash": {
         "type": "array",
         "byteArray": true,
         "minItems": 32,
         "maxItems": 32,
-        "description": "SHA256 hash of the bytes of the image specified by avatarUrl"
+        "description": "SHA256 hash of the bytes of the image specified by avatarUrl",
+        "position": 1
       },
       "avatarFingerprint": {
         "type": "array",
         "byteArray": true,
         "minItems": 8,
         "maxItems": 8,
-        "description": "dHash the image specified by avatarUrl"
+        "description": "dHash the image specified by avatarUrl",
+        "position": 2
       },
       "publicMessage": {
         "type": "string",
-        "maxLength": 140
+        "maxLength": 140,
+        "position": 3
       },
       "displayName": {
         "type": "string",
-        "maxLength": 25
+        "maxLength": 25,
+        "position": 4
       }
     },
     "required": [
@@ -156,21 +161,25 @@ An example contract for [DashPay](https://github.com/dashevo/platform/blob/maste
         "type": "array",
         "byteArray": true,
         "minItems": 32,
-        "maxItems": 32
+        "maxItems": 32,
+        "position": 0
       },
       "rootEncryptionKeyIndex": {
         "type": "integer",
-        "minimum": 0
+        "minimum": 0,
+        "position": 1
       },
       "derivationEncryptionKeyIndex": {
         "type": "integer",
-        "minimum": 0
+        "minimum": 0,
+        "position": 2
       },
       "privateData": {
         "type": "array",
         "byteArray": true,
         "minItems": 48,
         "maxItems": 2048,
+        "position": 3,
         "description": "This is the encrypted values of aliasName + note + displayHidden encoded as an array in cbor"
       }
     },
@@ -244,41 +253,49 @@ An example contract for [DashPay](https://github.com/dashevo/platform/blob/maste
         "byteArray": true,
         "minItems": 32,
         "maxItems": 32,
+        "position": 0,
         "contentMediaType": "application/x.dash.dpp.identifier"
       },
       "encryptedPublicKey": {
         "type": "array",
         "byteArray": true,
         "minItems": 96,
-        "maxItems": 96
+        "maxItems": 96,
+        "position": 1
       },
       "senderKeyIndex": {
         "type": "integer",
-        "minimum": 0
+        "minimum": 0,
+        "position": 2
       },
       "recipientKeyIndex": {
         "type": "integer",
-        "minimum": 0
+        "minimum": 0,
+        "position": 3
       },
       "accountReference": {
         "type": "integer",
-        "minimum": 0
+        "minimum": 0,
+        "position": 4
       },
       "encryptedAccountLabel": {
         "type": "array",
         "byteArray": true,
         "minItems": 48,
-        "maxItems": 80
+        "maxItems": 80,
+        "position": 5
       },
       "autoAcceptProof": {
         "type": "array",
         "byteArray": true,
         "minItems": 38,
-        "maxItems": 102
+        "maxItems": 102,
+        "position": 6
       },
       "coreHeightCreatedAt": {
         "type": "integer",
-        "minimum": 1
+        "minimum": 1,
+        "position": 7
       }
     },
     "required": [

--- a/docs/protocol-ref/data-contract.md
+++ b/docs/protocol-ref/data-contract.md
@@ -245,7 +245,8 @@ The following example shows a minimal `documents` object defining a single docum
     "type": "object",
     "properties": {
       "message": {
-        "type": "string"
+        "type": "string",
+        "position": 0
       }
     },
     "additionalProperties": false
@@ -268,13 +269,15 @@ const contractDocuments = {
         type: "object",
         properties: {
           objectProperty: {
-            type: "string"
+            type: "string",
+            position: 0
           },
         },
         additionalProperties: false,
       },
       header: {
-        type: "string"
+        type: "string",
+        position: 1
       }
     },
     additionalProperties: false
@@ -402,10 +405,12 @@ This example syntax shows the structure of a documents object that defines two d
     "type": "object",
     "properties": {
       "<field name b>": {
-        "type": "<field data type>"
+        "type": "<field data type>",
+        "position": "<number>"
       },
       "<field name c>": {
-        "type": "<field data type>"
+        "type": "<field data type>",
+        "position": "<number>"
       },
     },
     "indices": [
@@ -428,10 +433,12 @@ This example syntax shows the structure of a documents object that defines two d
     "type": "object",
     "properties": {
       "<property name y>": {
-        "type": "<property data type>"
+        "type": "<property data type>",
+        "position": "<number>"
       },
       "<property name z>": {
-        "type": "<property data type>"
+        "type": "<property data type>",
+        "position": "<number>"
       },
     },
     "additionalProperties": false

--- a/docs/tutorials/contracts-and-documents/register-a-data-contract.md
+++ b/docs/tutorials/contracts-and-documents/register-a-data-contract.md
@@ -37,7 +37,8 @@ The fifth tab shows a data contract using a byte array. This allows a contract t
     "type": "object",
     "properties": {
       "message": {
-        "type": "string"
+        "type": "string",
+        "position": 0
       }
     },
     "additionalProperties": false
@@ -57,7 +58,8 @@ The fifth tab shows a data contract using a byte array. This allows a contract t
     ],
     "properties": {
       "message": {
-        "type": "string"
+        "type": "string",
+        "position": 0
       }
     },
     "additionalProperties": false
@@ -74,7 +76,7 @@ An identity's documents are accessible via a query including a where clause like
 
 ```json
 //  3. References ($ref)
-// NOTE: The `$ref` keyword is temporarily disabled for Platform v0.22.
+// NOTE: The `$ref` keyword is temporarily disabled since Platform v0.22.
 {
   "customer": {
     "type": "object",
@@ -113,7 +115,8 @@ being added to the contract via the contracts `.setDefinitions` method:
     "type": "object",
     "properties": {
       "message": {
-        "type": "string"
+        "type": "string",
+        "position": 0
       }
     },
     "required": ["$createdAt", "$updatedAt"],
@@ -140,7 +143,8 @@ This information will be returned when the document is retrieved.
         "type": "array",
         "byteArray": true,
         "maxItems": 64,
-        "description": "Store block hashes"
+        "description": "Store block hashes",
+        "position": 0
       }
     },
     "additionalProperties": false
@@ -190,6 +194,7 @@ const registerContract = async () => {
       properties: {
         message: {
           type: 'string',
+          "position": 0
         },
       },
       additionalProperties: false,
@@ -240,6 +245,7 @@ const registerContract = async () => {
       properties: {
         message: {
           type: 'string',
+          "position": 0
         },
       },
       additionalProperties: false,
@@ -347,6 +353,7 @@ const registerContract = async () => {
       properties: {
         message: {
           type: 'string',
+          "position": 0
         },
       },
       required: ['$createdAt', '$updatedAt'],
@@ -395,6 +402,7 @@ const registerContract = async () => {
           byteArray: true,
           maxItems: 64,
           description: 'Store block hashes',
+          "position": 0
         },
       },
       additionalProperties: false,
@@ -439,6 +447,7 @@ const registerContract = async () => {
       properties: {
         message: {
           type: 'string',
+          "position": 0
         },
       },
       additionalProperties: false,

--- a/docs/tutorials/contracts-and-documents/register-a-data-contract.md
+++ b/docs/tutorials/contracts-and-documents/register-a-data-contract.md
@@ -26,6 +26,8 @@ The fifth tab shows a data contract using a byte array. This allows a contract t
 
 > 🚧
 >
+> Since Platform v0.25.16, each document property must assign `position` value to support [backwards compatibility](https://github.com/dashpay/platform/pull/1594) for contract updates.
+>
 > Since Platform v0.23, an index can [only use the ascending order](https://github.com/dashevo/platform/pull/435) (`asc`). Future updates will remove this restriction.
 
 ::::{tab-set-code}

--- a/docs/tutorials/contracts-and-documents/update-a-data-contract.md
+++ b/docs/tutorials/contracts-and-documents/update-a-data-contract.md
@@ -45,6 +45,7 @@ const updateContract = async () => {
 
   documentSchema.properties.author = {
     type: 'string',
+    position: 1,
   };
 
   existingDataContract.setDocumentSchema('note', documentSchema);
@@ -84,6 +85,7 @@ const updateContract = async () => {
 
   documentSchema.properties.author = {
     type: 'string',
+    position: 1,
   };
 
   existingDataContract.setDocumentSchema('note', documentSchema);


### PR DESCRIPTION
Changes due to https://github.com/dashpay/platform/pull/1594 which requires all document properties to use a new `position` field to support backwards compatibility when contracts are updated. Related to https://github.com/thephez/readme-tutorial-testing/pull/51.

<!-- Replace -->
Preview build: https://dash-docs-platform--35.org.readthedocs.build/en/35/
<!-- Replace -->
