### PR TITLE
feat: add credit transfer tutorial

### DIFF
--- a/docs/tutorials/identities-and-names.md
+++ b/docs/tutorials/identities-and-names.md
@@ -11,6 +11,7 @@ identities-and-names/retrieve-an-identity
 identities-and-names/topup-an-identity-balance
 identities-and-names/update-an-identity
 identities-and-names/retrieve-an-accounts-identities
+identities-and-names/transfer-credits-to-an-identity
 identities-and-names/register-a-name-for-an-identity
 identities-and-names/retrieve-a-name
 ```

--- a/docs/tutorials/identities-and-names/transfer-credits-to-an-identity.md
+++ b/docs/tutorials/identities-and-names/transfer-credits-to-an-identity.md
@@ -1,0 +1,66 @@
+# Transfer to an Identity
+
+The purpose of this tutorial is to walk through the steps necessary to transfer credits to an
+identity. Additional details regarding credits can be found in the [credits description](../../explanations/identity.md#credits).
+
+## Prerequisites
+
+- [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK
+  installed)
+- A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a
+  Wallet](../../tutorials/create-and-fund-a-wallet.md)
+- A Dash Platform Identity: [Tutorial: Register an
+  Identity](../../tutorials/identities-and-names/register-an-identity.md)
+
+## Code
+
+```javascript
+const Dash = require('dash');
+
+const clientOpts = {
+  network: 'testnet',
+  wallet: {
+    mnemonic: 'a Dash wallet mnemonic with testnet funds goes here',
+    unsafeOptions: {
+      skipSynchronizationBeforeHeight: 650000, // only sync from mid-2022
+    },
+  },
+};
+const client = new Dash.Client(clientOpts);
+
+const transferCreditsToIdentity = async () => {
+  const identityId = 'identity ID of the sender goes here';
+  const identity = await client.platform.identities.get(identityId);
+
+  const recipientID = 'identity ID of the recipient goes here';
+  console.log('Recipient identity balance before transfer: ', recipientIdentity.balance);
+  const transferAmount = 1000; // Number of credits to transfer
+
+  await client.platform.identities.creditTransfer(
+    identity,
+    recipientID,
+    transferAmount,
+  );
+  return client.platform.identities.get(identityId);
+};
+
+transferCreditsToIdentity()
+  .then((d) => console.log('Recipient identity balance after transfer: ', d.balance))
+  .catch((e) => console.error('Something went wrong:\n', e))
+  .finally(() => client.disconnect());
+```
+
+## What's Happening
+
+After connecting to the Client, we call `platform.identities.creditTransfer` with our identity, the recipient's identity ID, and the amount to transfer. This will generate a keypair
+and submit an _Identity Create State Transaction_. After the credits are transferred to the recipient, we retrieve the recipient's identity and output their updated balance to the console.
+
+> 📘 Wallet Operations
+>
+> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some
+> wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+
+> minutes.
+>
+> A future release will add caching so that access is much faster after the initial sync. For now,
+> the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain
+> block height.

--- a/docs/tutorials/identities-and-names/transfer-credits-to-an-identity.md
+++ b/docs/tutorials/identities-and-names/transfer-credits-to-an-identity.md
@@ -9,7 +9,7 @@ identity. Additional details regarding credits can be found in the [credits desc
   installed)
 - A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a
   Wallet](../../tutorials/create-and-fund-a-wallet.md)
-- A Dash Platform Identity: [Tutorial: Register an
+- Two Dash Platform Identities: [Tutorial: Register an
   Identity](../../tutorials/identities-and-names/register-an-identity.md)
 
 ## Code
@@ -52,8 +52,7 @@ transferCreditsToIdentity()
 
 ## What's Happening
 
-After connecting to the Client, we call `platform.identities.creditTransfer` with our identity, the recipient's identity ID, and the amount to transfer. This will generate a keypair
-and submit an _Identity Create State Transaction_. After the credits are transferred to the recipient, we retrieve the recipient's identity and output their updated balance to the console.
+After connecting to the Client, we call `platform.identities.creditTransfer` with our identity, the recipient's identity ID, and the amount to transfer. After the credits are transferred to the recipient, we retrieve the recipient's identity and output their updated balance to the console.
 
 > 📘 Wallet Operations
 >


### PR DESCRIPTION
Recent versions of Dash Platform have enabled the ability to transfer credits between identities. This pull request adds a tutorial to demonstrate this feature.

<!-- Replace -->
Preview build: https://dash-docs--43.org.readthedocs.build/projects/platform/en/43/docs/tutorials/identities-and-names/transfer-credits-to-an-identity.html
<!-- Replace -->
