### PR TITLE
docs: convert tutorials to named tabs

### DIFF
--- a/docs/tutorials/connecting-to-testnet.md
+++ b/docs/tutorials/connecting-to-testnet.md
@@ -100,15 +100,17 @@ connect()
 
 The example below demonstrates retrieving the hash of the best block hash directly from a DAPI node via command line and several languages:
 
-::::{tab-set-code}
-
+::::{tab-set}
+:::{tab-item} Curl
 ```shell
 curl --request POST \
   --url https://seed-1.testnet.networks.dash.org:1443/ \
   --header 'content-type: application/json' \
   --data '{"method":"getBlockHash","id":1,"jsonrpc":"2.0","params":{"height": 100 }}'
 ```
+:::
 
+:::{tab-item} Python
 ```python
 import requests
 
@@ -121,7 +123,9 @@ response = requests.request("POST", url, data=payload, headers=headers)
 
 print(response.text)
 ```
+:::
 
+:::{tab-item} Ruby
 ```ruby
 require 'uri'
 require 'net/http'
@@ -137,5 +141,5 @@ request.body = "{\"method\":\"getBlockHash\",\"id\":1,\"jsonrpc\":\"2.0\",\"para
 response = http.request(request)
 puts response.read_body
 ```
-
+:::
 ::::

--- a/docs/tutorials/contracts-and-documents/register-a-data-contract.md
+++ b/docs/tutorials/contracts-and-documents/register-a-data-contract.md
@@ -34,10 +34,10 @@ revisions to be retrieved in the future as needed.
 >
 > Since Platform v0.23, an index can [only use the ascending order](https://github.com/dashevo/platform/pull/435) (`asc`). Future updates will remove this restriction.
 
-::::{tab-set-code}
-
-```json 1. Minimal contract
-// 1. Minimal contract
+::::{tab-set}
+:::{tab-item} 1. Minimal contract
+:sync: minimal
+```json
 {
   "note": {
     "type": "object",
@@ -51,9 +51,11 @@ revisions to be retrieved in the future as needed.
   }
 }
 ```
+:::
 
-```json 2. Indexed
-//  2. Indexed
+:::{tab-item} 2. Indexed
+:sync: indexed
+```json
 {
   "note": {
     "type": "object",
@@ -79,9 +81,11 @@ An identity's documents are accessible via a query including a where clause like
 }
 */
 ```
+:::
 
+:::{tab-item} 3. Timestamps
+:sync: timestamp
 ```json
-//  3. Timestamps
 {
   "note": {
     "type": "object",
@@ -104,9 +108,11 @@ when the document was created or modified.
 This information will be returned when the document is retrieved.
 */
 ```
+:::
 
+:::{tab-item} 4. Binary data
+:sync: binary
 ```json
-// 4. Binary data
 {
  "block": {
    "type": "object",
@@ -128,7 +134,7 @@ Setting `"byteArray": true` indicates that the provided data will be an
 array of bytes (e.g. a NodeJS Buffer).
 */
 ```
-
+:::
 ::::
 
 > 📘
@@ -139,10 +145,10 @@ array of bytes (e.g. a NodeJS Buffer).
 
 The following examples demonstrate the details of creating contracts using the features [described above](#defining-contract-documents). Also, note that the sixth tab shows a data contract with contract history enabled to store each contract revision so it can be retrieved as needed for future reference:
 
-::::{tab-set-code}
-
-```javascript 1. Minimal contract
-// 1. Minimal contract
+::::{tab-set}
+:::{tab-item} 1. Minimal contract
+:sync: minimal
+```javascript
 const Dash = require('dash');
 
 const clientOpts = {
@@ -186,9 +192,11 @@ registerContract()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
+:::
 
-```javascript 2. Indexed
-// 2. Indexed
+:::{tab-item} 2. Indexed
+:sync: indexed
+```javascript
 const Dash = require('dash');
 
 const clientOpts = {
@@ -236,9 +244,11 @@ registerContract()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
+:::
 
-```javascript 3. Timestamps
-// 3. Timestamps
+:::{tab-item} 3. Timestamps
+:sync: timestamp
+```javascript
 const Dash = require('dash');
 
 const clientOpts = {
@@ -282,9 +292,11 @@ registerContract()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
+:::
 
-```javascript 4. Binary data
-// 4. Binary data
+:::{tab-item} 4. Binary data
+:sync: binary
+```javascript
 const Dash = require('dash');
 
 const clientOpts = {
@@ -330,9 +342,10 @@ registerContract()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
+:::
 
-```javascript 5. Contract with history
-// 5. Contract with history
+:::{tab-item} 5. Contract with history
+```javascript
 const Dash = require('dash');
 
 const clientOpts = {
@@ -383,7 +396,7 @@ registerContract()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
-
+:::
 ::::
 
 > 👍

--- a/docs/tutorials/contracts-and-documents/register-a-data-contract.md
+++ b/docs/tutorials/contracts-and-documents/register-a-data-contract.md
@@ -135,6 +135,27 @@ array of bytes (e.g. a NodeJS Buffer).
 */
 ```
 :::
+
+:::{tab-item} 5. Contract with history
+:sync: history
+```json
+// Identical to the minimal contract
+// Contract history configuration is done in code and
+// is not part of the contract itself.
+{
+  "note": {
+    "type": "object",
+    "properties": {
+      "message": {
+        "type": "string",
+        "position": 0
+      }
+    },
+    "additionalProperties": false
+  }
+}
+```
+:::
 ::::
 
 > 📘
@@ -345,6 +366,7 @@ registerContract()
 :::
 
 :::{tab-item} 5. Contract with history
+:sync: history
 ```javascript
 const Dash = require('dash');
 

--- a/docs/tutorials/contracts-and-documents/retrieve-documents.md
+++ b/docs/tutorials/contracts-and-documents/retrieve-documents.md
@@ -58,10 +58,9 @@ The values returned by `.toJSON()` include the base document properties (prefixe
 
 The values returned by `.getData()` (and also shown in the console.dir() `data` property) represent _only_ the properties defined in the `note` document described by the [tutorial data contract](../../tutorials/contracts-and-documents/register-a-data-contract.md#code).
 
-::::{tab-set-code}
-
-```json .toJSON()
-//  .toJSON()
+::::{tab-set}
+:::{tab-item} .toJSON()
+```json
 {
   "$protocolVersion": 0,
   "$id": "6LpCQhkXYV2vqkv1UWByew4xQ6BaxxnGkhfMZsN3SV9u",
@@ -72,21 +71,24 @@ The values returned by `.getData()` (and also shown in the console.dir() `data` 
   "message": "Tutorial CI Test @ Fri, 23 Jul 2021 13:12:13 GMT"
 }
 ```
+:::
 
-```json .getData()
-// .getData()
+:::{tab-item} .getData()
+```json
 {
   "Tutorial CI Test @ Fri, 23 Jul 2021 13:12:13 GMT"
 }
 ```
+:::
 
-```text .data.message
-# .data.message
+:::{tab-item} .data.message
+```text
 Tutorial CI Test @ Fri, 23 Jul 2021 13:12:13 GMT
 ```
+:::
 
-```json console.dir(document)
-// console.dir(document)
+:::{tab-item} console.dir(document)
+```text
 Document {
   dataContract: DataContract {
     protocolVersion: 0,
@@ -134,7 +136,7 @@ Document {
   metadata: Metadata { blockHeight: 526, coreChainLockedHeight: 542795 }
 }
 ```
-
+:::
 ::::
 
 ## What's happening

--- a/docs/tutorials/contracts-and-documents/update-a-data-contract.md
+++ b/docs/tutorials/contracts-and-documents/update-a-data-contract.md
@@ -19,10 +19,9 @@ In this tutorial we will update an existing data contract.
 
 The following examples demonstrate updating an existing contract to add a new property to an existing document. The second example shows how to update a contract that has contract history enabled:
 
-::::{tab-set-code}
-
-```javascript 1. Minimal contract
-// Minimal contract
+::::{tab-set}
+:::{tab-item} Minimal contract
+```javascript
 const Dash = require('dash');
 
 const clientOpts = {
@@ -60,9 +59,10 @@ updateContract()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
+:::
 
-```javascript 2. Contract with history
-// Contract with history
+:::{tab-item} Contract with history
+```javascript
 const Dash = require('dash');
 
 const clientOpts = {
@@ -103,7 +103,7 @@ updateContract()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
-
+:::
 ::::
 
 > 📘

--- a/docs/tutorials/identities-and-names/register-a-name-for-an-identity.md
+++ b/docs/tutorials/identities-and-names/register-a-name-for-an-identity.md
@@ -21,10 +21,9 @@ Dash Platform names make cryptographic identities easy to remember and communica
 
 **Note**: the name must be the full domain name including the parent domain (i.e. `myname.dash` instead of just `myname`). Currently `dash` is the only top-level domain that may be used.
 
-::::{tab-set-code}
-
-```javascript Register Name for Identity
-// Register Name for Identity
+::::{tab-set}
+:::{tab-item} Register Name for Identity
+```javascript
 const Dash = require('dash');
 
 const clientOpts = {
@@ -56,9 +55,10 @@ registerName()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
+:::
 
-```javascript Register Alias for Identity
-// Register Alias for Identity
+:::{tab-item} Register Alias for Identity
+```javascript
 const Dash = require('dash');
 
 const clientOpts = {
@@ -89,7 +89,7 @@ registerAlias()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
-
+:::
 ::::
 
 ## What's Happening

--- a/docs/tutorials/identities-and-names/retrieve-a-name.md
+++ b/docs/tutorials/identities-and-names/retrieve-a-name.md
@@ -8,10 +8,9 @@ In this tutorial we will retrieve the name created in the [Register a Name for a
 
 ## Code
 
-::::{tab-set-code}
-
-```javascript JavaScript - Resolve by Name
-//  Resolve by Name
+::::{tab-set}
+:::{tab-item} JavaScript - Resolve by Name
+```javascript
 const Dash = require('dash');
 
 const client = new Dash.Client({ network: 'testnet' });
@@ -26,9 +25,10 @@ retrieveName()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
+:::
 
-```javascript JavaScript - Revolve by Record
-// Revolve by Record
+:::{tab-item} JavaScript - Revolve by Record
+```javascript
 const Dash = require('dash');
 
 const client = new Dash.Client({ network: 'testnet' });
@@ -46,9 +46,10 @@ retrieveNameByRecord()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
+:::
 
-```javascript JavaScript - Search for Name
-// Search for Name
+:::{tab-item} JavaScript - Search for Name
+```javascript
 const Dash = require('dash');
 
 const client = new Dash.Client({ network: 'testnet' });
@@ -67,7 +68,7 @@ retrieveNameBySearch()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
-
+:::
 ::::
 
 ## Example Name

--- a/docs/tutorials/identities-and-names/update-an-identity.md
+++ b/docs/tutorials/identities-and-names/update-an-identity.md
@@ -16,10 +16,9 @@ The two examples below demonstrate updating an existing identity to add a new ke
 >
 > The current SDK version signs all state transitions with public key id `1`. If it is disabled, the SDK will be unable to use the identity. Future SDK versions will provide a way to also sign using keys added in an identity update.
 
-::::{tab-set-code}
-
-```javascript Disable identity key
-// Disable identity key
+::::{tab-set}
+:::{tab-item} Disable identity key
+```javascript
 const Dash = require('dash');
 
 const clientOpts = {
@@ -54,9 +53,10 @@ updateIdentityDisableKey()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
+:::
 
-```javascript Add identity key
-// Add identity key
+:::{tab-item} Add identity key
+```javascript
 const Dash = require('dash');
 const {
   PlatformProtocol: { IdentityPublicKey, IdentityPublicKeyWithWitness },
@@ -110,7 +110,7 @@ updateIdentityAddKey()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
-
+:::
 ::::
 
 ## What's Happening

--- a/docs/tutorials/node-setup/connect-to-a-network-dash-masternode.md
+++ b/docs/tutorials/node-setup/connect-to-a-network-dash-masternode.md
@@ -88,11 +88,9 @@ dashmate group status
 
 During development it may be necessary to obtain Dash to create and topup [identities](../../explanations/identity.md). This can be done using the dashmate `wallet:mint` command. First obtain an address to fund via the [Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md) tutorial and then mine Dash to it as shown below:
 
-::::{tab-set-code}
-
-```shell Mine to provided address
-# Mine to provided address
-
+::::{tab-set}
+:::{tab-item} Mine to provided address
+```shell
 # Stop the devnet first
 dashmate group stop
 
@@ -102,10 +100,10 @@ dashmate wallet mint 10 --address=<your address> --config=local_seed
 # Restart the devnet
 dashmate group start
 ```
+:::
 
-```shell Mine to new address
-# Mine to new address
-
+:::{tab-item} Mine to new address
+```shell
 # Stop the devnet first
 dashmate group:stop
 
@@ -116,7 +114,7 @@ dashmate wallet:mint 10 --config=local_seed
 # Restart the devnet
 dashmate group:start
 ```
-
+:::
 ::::
 
 Example output of `dashmate wallet mint 10 --address=yYqfdpePzn2kWtMxr9nz22HBFM7WBRmAqG --config=local_seed`:


### PR DESCRIPTION
Previously tab names were automatically created based on the type of code they contained. Switched to use [standard tabs](https://sphinx-design.readthedocs.io/en/latest/tabs.html) instead of code-specific ones so we can give the tabs custom names. This PR updates the tutorial section with the change.

<!-- Replace -->
Preview build: https://dash-docs-platform--49.org.readthedocs.build/en/49/
<!-- Replace -->
