### PR TITLE
fix: raise topUpAmount value

### DIFF
--- a/docs/tutorials/identities-and-names/topup-an-identity-balance.md
+++ b/docs/tutorials/identities-and-names/topup-an-identity-balance.md
@@ -34,7 +34,7 @@ const client = new Dash.Client(clientOpts);
 
 const topupIdentity = async () => {
   const identityId = 'an identity ID goes here';
-  const topUpAmount = 1000; // Number of duffs
+  const topUpAmount = 100000; // Number of duffs
 
   await client.platform.identities.topUp(identityId, topUpAmount);
   return client.platform.identities.get(identityId);


### PR DESCRIPTION
Right now the example code for [Topup an identity’s balance](https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/topup-an-identity-balance.html#code) results in an error:

```
Something went wrong:
 [StateTransitionBroadcastError: Asset lock transaction 7d3496d9835cd8885e56fb7fda0021ea60bf7ca3e902b5fd604d1298fceabce2 output 0 only has 1000 credits left out of 1000 initial credits on the asset lock but needs 50000 credits to start processing] {
  code: 10530,
  cause: IdentityAssetLockTransactionOutPointNotEnoughBalanceError {
    __wbg_ptr: 3280960
  }
}
```

Raising the value of `topUpAmount` above `50000` as mentioned in the error fixes the issue.

[Here's a quick repro of the error if you want to validate the fix](https://github.com/ajcwebdev/dash-error-repro).

<!-- Replace -->
Preview build: https://dash-docs-platform--53.org.readthedocs.build/en/53/
<!-- Replace -->
