### PR TITLE
refactor: extract client instantiation to separate section

### DIFF
--- a/_templates/sidebar-main.html
+++ b/_templates/sidebar-main.html
@@ -27,6 +27,8 @@
                     <li class="toctree-l1"><a class="reference internal"
                             href="docs/tutorials/create-and-fund-a-wallet.html">Create and
                             fund a wallet</a></li>
+                    <li class="toctree-l1"><a class="reference internal"
+                            href="docs/tutorials/setup-sdk-client.html">Setup SDK Client</a></li>
 
                     <li class="toctree-l1 has-children">
                         <a class="reference internal" href="docs/tutorials/identities-and-names.html">Identities and

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,6 +111,7 @@ intro/testnet
 tutorials/introduction
 tutorials/connecting-to-testnet
 tutorials/create-and-fund-a-wallet
+tutorials/client-setup
 tutorials/identities-and-names
 tutorials/contracts-and-documents
 tutorials/send-funds

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,7 +111,7 @@ intro/testnet
 tutorials/introduction
 tutorials/connecting-to-testnet
 tutorials/create-and-fund-a-wallet
-tutorials/client-setup
+tutorials/setup-sdk-client
 tutorials/identities-and-names
 tutorials/contracts-and-documents
 tutorials/send-funds

--- a/docs/tutorials/client-setup.md
+++ b/docs/tutorials/client-setup.md
@@ -1,0 +1,97 @@
+# Setup Client
+
+In this tutorial we will show how to configure the client for use in the remaining tutorials.
+
+## Prerequisites
+
+- [General prerequisites](../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
+- A wallet mnemonic with some funds in it: [How to Create and Fund a
+  Wallet](../tutorials/create-and-fund-a-wallet.md)
+
+## Code
+
+Save the following client configuration module in a file named `setupDashClient.js`. This module
+will be re-used in later tutorials.
+
+> 📘 Wallet Operations
+>
+> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some
+> wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+
+> minutes.
+>
+> A future release will add caching so that access is much faster after the initial sync. For now,
+> the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain
+> block height.
+
+```{code-block} javascript
+:caption: setupDashClient.js
+:name: setupDashClient.js
+
+// Fully configured client options
+const clientOptions = {
+  // The network to connect to ('testnet' or 'mainnet')
+  network: 'testnet',
+
+  // Wallet configuration for transactions and account management
+  wallet: {
+    // The mnemonic (seed phrase) for the wallet. Required for signing transactions.
+    mnemonic: 'a Dash wallet mnemonic with testnet funds goes here',
+
+    // Unsafe wallet options (use with caution)
+    unsafeOptions: {
+      // Starting synchronization from a specific block height can speed up the initial wallet sync process.
+      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
+    },
+
+    // The default account index to use for transactions and queries. Default is 0.
+    // defaultAccountIndex: 0,
+  },
+
+  // Configuration for Dash Platform applications
+  apps: {
+    // yourApp: { contractId: 'yourCustomAppContractId' },
+    tutorialContract: {
+      contractId: '8cvMFwa2YbEsNNoc1PXfTacy2PVq2SzVnkZLeQSzjfi6', // Contract ID
+    },
+  },
+
+  // Custom list of DAPI seed nodes to connect to. Overrides the default seed list.
+  // Format: { service: 'ip|domain:port' }
+  // seeds: [
+  //   { host: 'seed-1.testnet.networks.dash.org:1443' }
+  // ],
+
+  // Custom list of DAPI addresses to connect to
+  // Format: [ 'ip:port' }
+  // dapiAddresses: [ '127.0.0.1:3000' ],
+
+  // Request timeout in milliseconds for DAPI calls
+  // timeout: 3000,
+
+  // The number of retries for a failed DAPI request before giving up
+  // retries: 5,
+
+  // The base ban time in milliseconds for a DAPI node that fails to respond properly
+  // baseBanTime: 120000,
+};
+
+/**
+ * Creates and returns a Dash client instance
+ * @returns {Dash.Client} The Dash client instance.
+ */
+const setupDashClient = () => {
+  // Ensure that numeric values from environment variables are properly converted to numbers
+  if (clientOptions.wallet?.unsafeOptions?.skipSynchronizationBeforeHeight) {
+    clientOptions.wallet.unsafeOptions.skipSynchronizationBeforeHeight =
+      parseInt(
+        clientOptions.wallet.unsafeOptions.skipSynchronizationBeforeHeight,
+        10,
+      );
+  }
+  return new Dash.Client(clientOptions);
+};
+
+module.exports = setupDashClient;
+```
+
+## What's Happening

--- a/docs/tutorials/client-setup.md
+++ b/docs/tutorials/client-setup.md
@@ -13,16 +13,6 @@ In this tutorial we will show how to configure the client for use in the remaini
 Save the following client configuration module in a file named `setupDashClient.js`. This module
 will be re-used in later tutorials.
 
-> 📘 Wallet Operations
->
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some
-> wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+
-> minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now,
-> the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain
-> block height.
-
 ```{code-block} javascript
 :caption: setupDashClient.js
 :name: setupDashClient.js
@@ -94,4 +84,16 @@ const setupDashClient = () => {
 module.exports = setupDashClient;
 ```
 
+## Wallet Operations
+
+Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations (e.g. `client.getWalletAccount()`). A future release will add caching so that access is much faster after the initial sync.
+
+For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a
+certain block height. Set it to a height just below your wallet's first transaction height to
+minimize the sync time.
+
 ## What's Happening
+
+In this module, we return an SDK client configured with the options necessary for typical use. The
+module is then imported in the following tutorials to streamline them and avoid repeating client
+initialization details.

--- a/docs/tutorials/contracts-and-documents/delete-documents.md
+++ b/docs/tutorials/contracts-and-documents/delete-documents.md
@@ -10,28 +10,15 @@ In this tutorial we will update delete data from Dash Platform. Data is stored i
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 - A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 - Access to a previously created document (e.g., one created using the [Submit Documents tutorial](../../tutorials/contracts-and-documents/submit-documents.md))
 
 ## Code
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-  apps: {
-    tutorialContract: {
-      contractId: '8cvMFwa2YbEsNNoc1PXfTacy2PVq2SzVnkZLeQSzjfi6',
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const deleteNoteDocument = async () => {
   const { platform } = client;
@@ -67,8 +54,6 @@ Once the document has been retrieved, we must submit it to [DAPI](../../explanat
 
 The `platform.documents.broadcast` method takes the document batch (e.g. `{delete: [documents[0]]}`) and an identity parameter. Internally, it creates a [State Transition](../../explanations/platform-protocol-state-transition.md) containing the previously created document, signs the state transition, and submits the signed state transition to DAPI.
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+ minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../setup-sdk-client.md#wallet-operations) for options.

--- a/docs/tutorials/contracts-and-documents/register-a-data-contract.md
+++ b/docs/tutorials/contracts-and-documents/register-a-data-contract.md
@@ -10,6 +10,7 @@ In this tutorial we will register a data contract.
 
 * [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 * A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
+* A configured client: [Setup SDK Client](../setup-sdk-client.md)
 * A Dash Platform Identity: [Tutorial: Register an Identity](../../tutorials/identities-and-names/register-an-identity.md)
 
 ## Code
@@ -174,18 +175,9 @@ The following examples demonstrate the details of creating contracts using the f
 :::{tab-item} 1. Minimal contract
 :sync: minimal
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },    
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const registerContract = async () => {
   const { platform } = client;
@@ -222,18 +214,9 @@ registerContract()
 :::{tab-item} 2. Indexed
 :sync: indexed
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const registerContract = async () => {
   const { platform } = client;
@@ -274,18 +257,9 @@ registerContract()
 :::{tab-item} 3. Timestamps
 :sync: timestamp
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const registerContract = async () => {
   const { platform } = client;
@@ -322,18 +296,9 @@ registerContract()
 :::{tab-item} 4. Binary data
 :sync: binary
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const registerContract = async () => {
   const { platform } = client;
@@ -372,18 +337,9 @@ registerContract()
 :::{tab-item} 5. Contract with history
 :sync: history
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const registerContract = async () => {
   const { platform } = client;
@@ -435,8 +391,6 @@ After we initialize the Client, we create an object defining the documents this 
 
 Once the data contract has been created, we still need to submit it to DAPI. The `platform.contracts.publish` method takes a data contract and an identity parameter. Internally, it creates a State Transition containing the previously created contract, signs the state transition, and submits the signed state transition to DAPI. A response will only be returned if an error is encountered.
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+ minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../setup-sdk-client.md#wallet-operations) for options.

--- a/docs/tutorials/contracts-and-documents/retrieve-a-data-contract.md
+++ b/docs/tutorials/contracts-and-documents/retrieve-a-data-contract.md
@@ -9,6 +9,7 @@ In this tutorial we will retrieve the data contract created in the [Register a D
 ## Prerequisites
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 - A Dash Platform Contract ID: [Tutorial: Register a Data Contract](../../tutorials/contracts-and-documents/register-a-data-contract.md)
 
 ## Code
@@ -16,9 +17,9 @@ In this tutorial we will retrieve the data contract created in the [Register a D
 ### Retrieving a data contract
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const client = new Dash.Client({ network: 'testnet' });
+const client = setupDashClient();
 
 const retrieveContract = async () => {
   const contractId = '8cvMFwa2YbEsNNoc1PXfTacy2PVq2SzVnkZLeQSzjfi6';

--- a/docs/tutorials/contracts-and-documents/retrieve-data-contract-history.md
+++ b/docs/tutorials/contracts-and-documents/retrieve-data-contract-history.md
@@ -12,6 +12,7 @@ information.
 ## Prerequisites
 
 * [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
+* A configured client: [Setup SDK Client](../setup-sdk-client.md)
 * A Dash Platform contract ID for a contract configured to keep history: [Tutorial: Register a Data Contract](../../tutorials/contracts-and-documents/register-a-data-contract.md)
 
 ## Code
@@ -19,9 +20,9 @@ information.
 ### Retrieving data contract history
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const client = new Dash.Client({ network: 'testnet' });
+const client = setupDashClient();
 
 const retrieveContractHistory = async () => {
   const contractId = '8cvMFwa2YbEsNNoc1PXfTacy2PVq2SzVnkZLeQSzjfi6'

--- a/docs/tutorials/contracts-and-documents/retrieve-documents.md
+++ b/docs/tutorials/contracts-and-documents/retrieve-documents.md
@@ -9,22 +9,14 @@ In this tutorial we will retrieve some of the current data from a data contract.
 ## Prerequisites
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
-- A Dash Platform Contract ID: [Tutorial: Register a Data Contract](../../tutorials/contracts-and-documents/register-a-data-contract.md)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)- A Dash Platform Contract ID: [Tutorial: Register a Data Contract](../../tutorials/contracts-and-documents/register-a-data-contract.md)
 
 ## Code
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  apps: {
-    tutorialContract: {
-      contractId: '8cvMFwa2YbEsNNoc1PXfTacy2PVq2SzVnkZLeQSzjfi6',
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const getDocuments = async () => {
   return client.platform.documents.get('tutorialContract.note', {

--- a/docs/tutorials/contracts-and-documents/submit-documents.md
+++ b/docs/tutorials/contracts-and-documents/submit-documents.md
@@ -10,29 +10,16 @@ In this tutorial we will submit some data to an application on Dash Platform. Da
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 - A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 - A Dash Platform Identity: [Tutorial: Register an Identity](../../tutorials/identities-and-names/register-an-identity.md)
 - A Dash Platform Contract ID: [Tutorial: Register a Data Contract](../../tutorials/contracts-and-documents/register-a-data-contract.md)
 
 ## Code
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-  apps: {
-    tutorialContract: {
-      contractId: '8cvMFwa2YbEsNNoc1PXfTacy2PVq2SzVnkZLeQSzjfi6',
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const submitNoteDocument = async () => {
   const { platform } = client;
@@ -77,8 +64,6 @@ Once the document has been created, we still need to submit it to [DAPI](../../e
 
 The `platform.documents.broadcast` method then takes the document batch and an identity parameter. Internally, it creates a [State Transition](../../explanations/platform-protocol-state-transition.md) containing the previously created document, signs the state transition, and submits the signed state transition to DAPI.
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+ minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../setup-sdk-client.md#wallet-operations) for options.

--- a/docs/tutorials/contracts-and-documents/update-a-data-contract.md
+++ b/docs/tutorials/contracts-and-documents/update-a-data-contract.md
@@ -16,6 +16,7 @@ In this tutorial we will update an existing data contract.
 
 * [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 * A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
+* A configured client: [Setup SDK Client](../setup-sdk-client.md)
 * A Dash Platform Identity: [Tutorial: Register an Identity](../../tutorials/identities-and-names/register-an-identity.md)
 * A Dash Platform Contract ID: [Tutorial: Register a Data Contract](../../tutorials/contracts-and-documents/register-a-data-contract.md)
 
@@ -26,18 +27,9 @@ The following examples demonstrate updating an existing contract to add a new pr
 ::::{tab-set}
 :::{tab-item} Minimal contract
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },    
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const updateContract = async () => {
   const { platform } = client;
@@ -67,18 +59,9 @@ updateContract()
 
 :::{tab-item} Contract with history
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },    
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const updateContract = async () => {
   const { platform } = client;
@@ -120,8 +103,6 @@ After we initialize the Client, we retrieve an existing contract owned by our id
 
 Once the data contract has been updated, we still need to submit it to DAPI. The `platform.contracts.update` method takes a data contract and an identity parameter. Internally, it creates a State Transition containing the updated contract, signs the state transition, and submits the signed state transition to DAPI. A response will only be returned if an error is encountered.
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+ minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../setup-sdk-client.md#wallet-operations) for options.

--- a/docs/tutorials/contracts-and-documents/update-documents.md
+++ b/docs/tutorials/contracts-and-documents/update-documents.md
@@ -10,28 +10,15 @@ In this tutorial we will update existing data on Dash Platform. Data is stored i
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 - A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 - Access to a previously created document (e.g., one created using the [Submit Documents tutorial](../../tutorials/contracts-and-documents/submit-documents.md))
 
 ## Code
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-  apps: {
-    tutorialContract: {
-      contractId: '8cvMFwa2YbEsNNoc1PXfTacy2PVq2SzVnkZLeQSzjfi6',
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const updateNoteDocument = async () => {
   const { platform } = client;
@@ -68,8 +55,6 @@ After we initialize the Client, we retrieve the document to be updated via `plat
 
 The `platform.documents.broadcast` method then takes the document batch (e.g. `{replace: [noteDocument]}`) and an identity parameter. Internally, it creates a [State Transition](../../explanations/platform-protocol-state-transition.md) containing the previously created document, signs the state transition, and submits the signed state transition to DAPI.
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+ minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../setup-sdk-client.md#wallet-operations) for options.

--- a/docs/tutorials/identities-and-names/register-a-name-for-an-identity.md
+++ b/docs/tutorials/identities-and-names/register-a-name-for-an-identity.md
@@ -16,6 +16,7 @@ Dash Platform names make cryptographic identities easy to remember and communica
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 - A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 - A Dash Platform identity: [Tutorial: Register an Identity](../../tutorials/identities-and-names/register-an-identity.md)
 - A name you want to register: [Name restrictions](../../explanations/dpns.md#implementation)
 
@@ -28,18 +29,9 @@ Dash Platform names make cryptographic identities easy to remember and communica
 ::::{tab-set}
 :::{tab-item} Register Name for Identity
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with testnet funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const registerName = async () => {
   const { platform } = client;
@@ -63,18 +55,9 @@ registerName()
 
 :::{tab-item} Register Alias for Identity
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with testnet funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const registerAlias = async () => {
   const platform = client.platform;
@@ -100,8 +83,6 @@ registerAlias()
 
 After initializing the Client, we fetch the Identity we'll be associating with a name. This is an asynchronous method so we use _await_ to pause until the request is complete. Next, we call `platform.names.register` and pass in the name we want to register, the type of identity record to create, and the identity we just fetched. We wait for the result, and output it to the console.
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+ minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../setup-sdk-client.md#wallet-operations) for options.

--- a/docs/tutorials/identities-and-names/register-an-identity.md
+++ b/docs/tutorials/identities-and-names/register-an-identity.md
@@ -14,28 +14,18 @@ Identities serve as the basis for interactions with Dash Platform. They consist 
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 - A wallet mnemonic with some funds in it: [How to Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
+- A configured client: [Setup Client](../client-setup.md)
 
 ## Code
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+ minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../client-setup.md#wallet-operations) for options.
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with testnet funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const createIdentity = async () => {
   return client.platform.identities.register();

--- a/docs/tutorials/identities-and-names/register-an-identity.md
+++ b/docs/tutorials/identities-and-names/register-an-identity.md
@@ -14,7 +14,7 @@ Identities serve as the basis for interactions with Dash Platform. They consist 
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 - A wallet mnemonic with some funds in it: [How to Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
-- A configured client: [Setup Client](../setup-sdk-client.md)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 
 ## Code
 

--- a/docs/tutorials/identities-and-names/register-an-identity.md
+++ b/docs/tutorials/identities-and-names/register-an-identity.md
@@ -14,13 +14,13 @@ Identities serve as the basis for interactions with Dash Platform. They consist 
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 - A wallet mnemonic with some funds in it: [How to Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
-- A configured client: [Setup Client](../client-setup.md)
+- A configured client: [Setup Client](../setup-sdk-client.md)
 
 ## Code
 
 > 📘 Wallet Sync
 >
-> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../client-setup.md#wallet-operations) for options.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../setup-sdk-client.md#wallet-operations) for options.
 
 ```javascript
 const setupDashClient = require('../setupDashClient');

--- a/docs/tutorials/identities-and-names/retrieve-a-name.md
+++ b/docs/tutorials/identities-and-names/retrieve-a-name.md
@@ -9,15 +9,16 @@ In this tutorial we will retrieve the name created in the [Register a Name for a
 ## Prerequisites
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 
 ## Code
 
 ::::{tab-set}
 :::{tab-item} JavaScript - Resolve by Name
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const client = new Dash.Client({ network: 'testnet' });
+const client = setupDashClient();
 
 const retrieveName = async () => {
   // Retrieve by full name (e.g., myname.dash)
@@ -33,9 +34,9 @@ retrieveName()
 
 :::{tab-item} JavaScript - Revolve by Record
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const client = new Dash.Client({ network: 'testnet' });
+const client = setupDashClient();
 
 const retrieveNameByRecord = async () => {
   // Retrieve by a name's identity ID
@@ -54,9 +55,9 @@ retrieveNameByRecord()
 
 :::{tab-item} JavaScript - Search for Name
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const client = new Dash.Client({ network: 'testnet' });
+const client = setupDashClient();
 
 const retrieveNameBySearch = async () => {
   // Search for names (e.g. `user*`)

--- a/docs/tutorials/identities-and-names/retrieve-an-accounts-identities.md
+++ b/docs/tutorials/identities-and-names/retrieve-an-accounts-identities.md
@@ -10,22 +10,15 @@ In this tutorial we will retrieve the list of identities associated with a speci
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 - A wallet mnemonic
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 - A Dash Platform Identity: [Tutorial: Register an Identity](../../tutorials/identities-and-names/register-an-identity.md)
 
 ## Code
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const client = new Dash.Client({
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with testnet funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-});
+const client = setupDashClient();
 
 const retrieveIdentityIds = async () => {
   const account = await client.getWalletAccount();
@@ -53,8 +46,6 @@ Example Response
 
 After we initialize the Client and getting the account, we call `account.identities.getIdentityIds()` to retrieve a list of all identities created with the wallet mnemonic. The list of identities is output to the console.
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+ minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../setup-sdk-client.md#wallet-operations) for options.

--- a/docs/tutorials/identities-and-names/retrieve-an-identity.md
+++ b/docs/tutorials/identities-and-names/retrieve-an-identity.md
@@ -14,9 +14,9 @@ In this tutorial we will retrieve the identity created in the [Register an Ident
 ## Code
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const client = new Dash.Client({ network: 'testnet' });
+const client = setupDashClient();
 
 const retrieveIdentity = async () => {
   return client.platform.identities.get('an identity ID goes here');

--- a/docs/tutorials/identities-and-names/retrieve-an-identity.md
+++ b/docs/tutorials/identities-and-names/retrieve-an-identity.md
@@ -9,6 +9,7 @@ In this tutorial we will retrieve the identity created in the [Register an Ident
 ## Prerequisites
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 - A Dash Platform Identity: [Tutorial: Register an Identity](../../tutorials/identities-and-names/register-an-identity.md)
 
 ## Code

--- a/docs/tutorials/identities-and-names/topup-an-identity-balance.md
+++ b/docs/tutorials/identities-and-names/topup-an-identity-balance.md
@@ -14,6 +14,7 @@ As users interact with Dash Platform applications, the credit balance associated
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 - A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 - A Dash Platform Identity: [Tutorial: Register an Identity](../../tutorials/identities-and-names/register-an-identity.md)
 
 ## Code

--- a/docs/tutorials/identities-and-names/topup-an-identity-balance.md
+++ b/docs/tutorials/identities-and-names/topup-an-identity-balance.md
@@ -19,18 +19,9 @@ As users interact with Dash Platform applications, the credit balance associated
 ## Code
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with testnet funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const topupIdentity = async () => {
   const identityId = 'an identity ID goes here';
@@ -50,8 +41,6 @@ topupIdentity()
 
 After connecting to the Client, we call `platform.identities.topUp` with an identity ID and a topup amount in duffs (1 duff = 1000 credits). This creates a lock transaction and increases the identity's credit balance by the relevant amount (minus fee). The updated balance is output to the console.
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+ minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../client-setup.md#wallet-operations) for options.

--- a/docs/tutorials/identities-and-names/topup-an-identity-balance.md
+++ b/docs/tutorials/identities-and-names/topup-an-identity-balance.md
@@ -43,4 +43,4 @@ After connecting to the Client, we call `platform.identities.topUp` with an iden
 
 > 📘 Wallet Sync
 >
-> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../client-setup.md#wallet-operations) for options.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../setup-sdk-client.md#wallet-operations) for options.

--- a/docs/tutorials/identities-and-names/transfer-credits-to-an-identity.md
+++ b/docs/tutorials/identities-and-names/transfer-credits-to-an-identity.md
@@ -13,24 +13,16 @@ identity. Additional details regarding credits can be found in the [credits desc
   installed)
 - A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a
   Wallet](../../tutorials/create-and-fund-a-wallet.md)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 - Two Dash Platform Identities: [Tutorial: Register an
   Identity](../../tutorials/identities-and-names/register-an-identity.md)
 
 ## Code
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with testnet funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const transferCreditsToIdentity = async () => {
   const identityId = 'identity ID of the sender goes here';
@@ -58,12 +50,6 @@ transferCreditsToIdentity()
 
 After connecting to the Client, we call `platform.identities.creditTransfer` with our identity, the recipient's identity ID, and the amount to transfer. After the credits are transferred to the recipient, we retrieve the recipient's identity and output their updated balance to the console.
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some
-> wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+
-> minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now,
-> the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain
-> block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](../setup-sdk-client.md#wallet-operations) for options.

--- a/docs/tutorials/identities-and-names/update-an-identity.md
+++ b/docs/tutorials/identities-and-names/update-an-identity.md
@@ -10,6 +10,7 @@ Since Dash Platform v0.23, it is possible to update identities to add new keys o
 
 - [General prerequisites](../../tutorials/introduction.md#prerequisites) (Node.js / Dash SDK installed)
 - A wallet mnemonic with some funds in it: [Tutorial: Create and Fund a Wallet](../../tutorials/create-and-fund-a-wallet.md)
+- A configured client: [Setup SDK Client](../setup-sdk-client.md)
 - A Dash Platform Identity: [Tutorial: Register an Identity](../../tutorials/identities-and-names/register-an-identity.md)
 
 ## Code

--- a/docs/tutorials/identities-and-names/update-an-identity.md
+++ b/docs/tutorials/identities-and-names/update-an-identity.md
@@ -23,18 +23,9 @@ The two examples below demonstrate updating an existing identity to add a new ke
 ::::{tab-set}
 :::{tab-item} Disable identity key
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },    
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const updateIdentityDisableKey = async () => {
   const identityId = 'an identity ID goes here';
@@ -61,21 +52,9 @@ updateIdentityDisableKey()
 
 :::{tab-item} Add identity key
 ```javascript
-const Dash = require('dash');
-const {
-  PlatformProtocol: { IdentityPublicKey, IdentityPublicKeyWithWitness },
-} = Dash;
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'a Dash wallet mnemonic with funds goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },    
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const updateIdentityAddKey = async () => {
   const identityId = 'an identity ID goes here';

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -25,6 +25,7 @@ The tutorials in this section are written in JavaScript and use [Node.js](https:
 While going through each tutorial is advantageous, the subset of tutorials listed below get you from a start to storing data on Dash Platform most quickly:
 
 - [Obtaining test funds](../tutorials/create-and-fund-a-wallet.md)
+- [Setting up client options](../tutorials/client-setup.md)
 - [Registering an Identity](../tutorials/identities-and-names/register-an-identity.md)
 - [Registering a Data Contract](../tutorials/contracts-and-documents/register-a-data-contract.md)
 - [Submitting data](../tutorials/contracts-and-documents/submit-documents.md)

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -25,7 +25,7 @@ The tutorials in this section are written in JavaScript and use [Node.js](https:
 While going through each tutorial is advantageous, the subset of tutorials listed below get you from a start to storing data on Dash Platform most quickly:
 
 - [Obtaining test funds](../tutorials/create-and-fund-a-wallet.md)
-- [Setting up client options](../tutorials/client-setup.md)
+- [Setting up client options](../tutorials/setup-sdk-client.md)
 - [Registering an Identity](../tutorials/identities-and-names/register-an-identity.md)
 - [Registering a Data Contract](../tutorials/contracts-and-documents/register-a-data-contract.md)
 - [Submitting data](../tutorials/contracts-and-documents/submit-documents.md)

--- a/docs/tutorials/send-funds.md
+++ b/docs/tutorials/send-funds.md
@@ -8,25 +8,14 @@ Once you have a wallet and some funds ([tutorial](../tutorials/create-and-fund-a
 
 # Code
 
-> 📘 Wallet Operations
+> 📘 Wallet Sync
 >
-> The JavaScript SDK does not cache wallet information. It re-syncs the entire Core chain for some wallet operations (e.g. `client.getWalletAccount()`) which can result in wait times of  5+ minutes.
->
-> A future release will add caching so that access is much faster after the initial sync. For now, the `skipSynchronizationBeforeHeight` option can be used to sync the wallet starting at a certain block height.
+> Since the SDK does not cache wallet information, lengthy re-syncs (5+ minutes) may be required for some Core chain wallet operations. See [Wallet Operations](./setup-sdk-client.md#wallet-operations) for options.
 
 ```javascript
-const Dash = require('dash');
+const setupDashClient = require('../setupDashClient');
 
-const clientOpts = {
-  network: 'testnet',
-  wallet: {
-    mnemonic: 'your wallet mnemonic goes here',
-    unsafeOptions: {
-      skipSynchronizationBeforeHeight: 875000, // only sync from mid-2023
-    },
-  },
-};
-const client = new Dash.Client(clientOpts);
+const client = setupDashClient();
 
 const sendFunds = async () => {
   const account = await client.getWalletAccount();

--- a/docs/tutorials/setup-sdk-client.md
+++ b/docs/tutorials/setup-sdk-client.md
@@ -1,4 +1,4 @@
-# Setup Client
+# Setup SDK Client
 
 In this tutorial we will show how to configure the client for use in the remaining tutorials.
 


### PR DESCRIPTION
Client instantiation is now handled outside the individual tutorials. This both cuts down on the amount of code present in each tutorial and makes it easy to modify client options. Many of the SDK client options are also provided (commented out) in the new `setupDashClient` module.

Related to dashpay/platform-tutorials/#36