### PR TITLE
docs: pin sdk version to testnet version

### DIFF
--- a/docs/tutorials/connecting-to-testnet.md
+++ b/docs/tutorials/connecting-to-testnet.md
@@ -21,7 +21,7 @@ Platform services are provided via a combination of HTTP and gRPC connections to
 The JavaScript SDK package is available from npmjs.com and can be installed by running `npm install dash` from the command line:
 
 ```shell
-npm install dash@1.0-dev
+npm install dash@1.0.0-dev.12
 ```
 
 ### 2. Connect to Dash Platform


### PR DESCRIPTION
Testnet is not currently on the latest dev release, so this pins the sdk version to one that matches testnet.

<!-- Replace -->
Preview build: https://dash-docs-platform--59.org.readthedocs.build/en/59/
<!-- Replace -->
