### PR TITLE
docs: update contract registration tutorial to include nft example

### DIFF
--- a/docs/explanations/nft.md
+++ b/docs/explanations/nft.md
@@ -49,7 +49,7 @@ Structurally, there is no difference between an NFT contract and a non-NFT contr
 
 NFT contracts will often set document creation restrictions and enable document transfers. Default options for modifying, deleting, and transferring documents can be specified at the contract level and overridden as needed for specific document types.
 
-Once the data contract design is completed, the contract can be registered on the network in preparation for NFT document creation.
+Once the data contract design is completed, the contract can be registered on the network in preparation for NFT document creation. See the [contract registration tutorial](../tutorials/contracts-and-documents/register-a-data-contract.md) for example code.
 
 ### Minting NFTs
 


### PR DESCRIPTION
Although the JS SDK does not support the state transitions required to transfer documents, set prices, or purchase documents, contracts for NFTs can still be registered since they're regular contracts with some options configured.

This PR includes an example contract for a simple NFT in the contract registration tutorial (to show how the relevant contract options might be set). Technically NFT documents for the contract can be created/deleted with the JS SDK also. Since doc create/delete work identically to any other doc, those tutorials were not updated.

Preview: https://dash-docs--62.org.readthedocs.build/projects/platform/en/62/docs/tutorials/contracts-and-documents/register-a-data-contract.html