### PR TITLE
docs: names no longer use dashUnique and dashAlias IdentityIds

### DIFF
--- a/docs/sdk-js/platform/names/register.md
+++ b/docs/sdk-js/platform/names/register.md
@@ -9,10 +9,9 @@ Parameters:
 | -------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **name**                         | String   | yes      | An alphanumeric (1-63 character) value used for human-identification (can contain `-` but not as the first or last character). If a name with no parent domain is entered, '.dash' is used. |
 | **records**                      | Object   | yes      | records object having only one of the following items                                                                                                                                       |
-| **records.dashUniqueIdentityId** | String   | no       | Unique Identity ID for this name record                                                                                                                                                     |
-| **records.dashAliasIdentityId**  | String   | no       | Used to signify that this name is the alias for another id                                                                                                                                  |
+| **records.identity**             | String   | yes      | Identity ID for this name record                                                                                                                     |
 | **identity**                     | Identity | yes      | A valid [registered identity](../identities/register.md)                                                                                             |
 
-**Example**: `await client.platform.names.register('alice', { dashUniqueIdentityId: identity.getId() }, identity)`
+**Example**: `await client.platform.names.register('alice', { identity: identity.getId() }, identity)`
 
 Returns: the created domain document

--- a/docs/sdk-js/platform/names/resolvebyrecord.md
+++ b/docs/sdk-js/platform/names/resolvebyrecord.md
@@ -7,16 +7,16 @@ Parameters:
 
 | Parameters | Type   | Required | Description                                                          |
 | ---------- | ------ | -------- | -------------------------------------------------------------------- |
-| **record** | String | yes      | Type of the record (`dashUniqueIdentityId` or `dashAliasIdentityId`) |
+| **record** | String | yes      | Type of the record (`identity`) |
 | **value**  | String | yes      | Identifier value for the record                                      |
 
 **Example**:
 
-This example will describe how to resolve names by the dash unique identity id.  
+This example will describe how to resolve names by the dash unique identity id.
 
 ```js
 const identityId = '3ge4yjGinQDhxh2aVpyLTQaoka45BkijkoybfAkDepoN';
-const document = await client.platform.names.resolveByRecord('dashUniqueIdentityId', identityId);
+const document = await client.platform.names.resolveByRecord('identity', identityId);
 ```
 
 Returns: array of ExtendedDocument.

--- a/docs/tutorials/identities-and-names/register-a-name-for-an-identity.md
+++ b/docs/tutorials/identities-and-names/register-a-name-for-an-identity.md
@@ -8,9 +8,7 @@ The purpose of this tutorial is to walk through the steps necessary to register 
 
 ## Overview
 
-Dash Platform names make cryptographic identities easy to remember and communicate. An identity may have multiple alias names (`dashAliasIdentityId`) in addition to its default name (`dashUniqueIdentityId`). Additional details regarding identities can be found in the [Identity description](../../explanations/identity.md).
-
-**Note**: An identity must have a default name before any aliases can be created for the identity.
+Dash Platform names make cryptographic identities easy to remember and communicate by enabling them to link to one or more names. Additional details regarding identities can be found in the [Identity description](../../explanations/identity.md).
 
 ## Prerequisites
 
@@ -22,12 +20,10 @@ Dash Platform names make cryptographic identities easy to remember and communica
 
 ## Code
 
- The examples below demonstrate creating both the default name and alias names.
+:::{tip}
+The name must be the full domain name including the parent domain (i.e. `myname.dash` rather than `myname`). Currently, only the `dash` top-level domain may be used.
+:::
 
-**Note**: the name must be the full domain name including the parent domain (i.e. `myname.dash` instead of just `myname`). Currently `dash` is the only top-level domain that may be used.
-
-::::{tab-set}
-:::{tab-item} Register Name for Identity
 ```javascript
 const setupDashClient = require('../setupDashClient');
 
@@ -39,7 +35,7 @@ const registerName = async () => {
   const identity = await platform.identities.get('an identity ID goes here');
   const nameRegistration = await platform.names.register(
     '<identity name goes here>.dash',
-    { dashUniqueIdentityId: identity.getId() },
+    { identity: identity.getId() },
     identity,
   );
 
@@ -51,33 +47,6 @@ registerName()
   .catch((e) => console.error('Something went wrong:\n', e))
   .finally(() => client.disconnect());
 ```
-:::
-
-:::{tab-item} Register Alias for Identity
-```javascript
-const setupDashClient = require('../setupDashClient');
-
-const client = setupDashClient();
-
-const registerAlias = async () => {
-  const platform = client.platform;
-  const identity = await platform.identities.get('an identity ID goes here');
-  const aliasRegistration = await platform.names.register(
-    '<identity alias goes here>.dash',
-    { dashAliasIdentityId: identity.getId() },
-    identity,
-  );
-
-  return aliasRegistration;
-};
-
-registerAlias()
-  .then((d) => console.log('Alias registered:\n', d.toJSON()))
-  .catch((e) => console.error('Something went wrong:\n', e))
-  .finally(() => client.disconnect());
-```
-:::
-::::
 
 ## What's Happening
 

--- a/docs/tutorials/identities-and-names/retrieve-a-name.md
+++ b/docs/tutorials/identities-and-names/retrieve-a-name.md
@@ -41,7 +41,7 @@ const client = setupDashClient();
 const retrieveNameByRecord = async () => {
   // Retrieve by a name's identity ID
   return client.platform.names.resolveByRecord(
-    'dashUniqueIdentityId',
+    'identity',
     '<identity id>',
   );
 };
@@ -78,18 +78,17 @@ retrieveNameBySearch()
 
 ## Example Name
 
-The following example response shows a retrieved name (`user-9999.dash`):
+The following example response shows a retrieved name:
 
 ```json
 {
-  "label": "Alice",
-  "normalizedLabel": "alice",
+  "label": "Tutorial-Test-Jettie-94475",
+  "normalizedLabel": "tut0r1a1-test-jett1e-94475",
   "normalizedParentDomainName": "dash",
-  "preorderSalt": "lQEiixHMO5TJmbKwKtavg6eAkxuXzvSlrs/OX9glcYI=",
+  "parentDomainName": "dash",
   "records": {
-    "dashAliasIdentityId": null,
-    "dashUniqueIdentityId": "YhCPn6pSbZ11hCiFmFL6WJkmC3GSwuUSzhS4QAy84EF"
-  },  
+    "identity": "woTQprzGS4bLqqbAhY2heG8QfD58Doo2UhDbiVVrLKG"
+  },
   "subdomainRules": {
     "allowSubdomains": false
   }
@@ -101,7 +100,7 @@ The following example response shows a retrieved name (`user-9999.dash`):
 After we initialize the Client, we request a name. The [code examples](#code) demonstrate the three ways to request a name:
 
 1. Resolve by name. The `platform.names.resolve` method takes a single argument: a fully-qualified name (e.g., `user-9999.dash`).
-2. Resolve by record. The `platform.names.resolveByRecord` method takes two arguments: the record type (e.g., `dashUniqueIdentityId`) and the record value to resolve.
+2. Resolve by record. The `platform.names.resolveByRecord` method takes two arguments: the record type (e.g., `identity`) and the record value to resolve.
 3. Search. The `platform.names.search` method takes two arguments: the leading characters of the name to search for and the domain to search (e.g., `dash` for names in the `*.dash` domain). The search will return names that begin the with string provided in the first parameter.
 
 After the name is retrieved, it is displayed on the console.


### PR DESCRIPTION
Platform v1 changed the name/identity relationship and removed the unique/alias record types. Now it only uses a single identity record type since https://github.com/dashpay/platform/pull/1984

<!-- Replace -->
Preview build: https://dash-docs-platform--72.org.readthedocs.build/en/72/
<!-- Replace -->
