### PR TITLE
docs: update to install the latest stable sdk release

### DIFF
--- a/docs/tutorials/connecting-to-testnet.md
+++ b/docs/tutorials/connecting-to-testnet.md
@@ -21,7 +21,7 @@ Platform services are provided via a combination of HTTP and gRPC connections to
 The JavaScript SDK package is available from npmjs.com and can be installed by running `npm install dash` from the command line:
 
 ```shell
-npm install dash@~4.1.0-dev
+npm install dash
 ```
 
 ### 2. Connect to Dash Platform


### PR DESCRIPTION
Now that [v1.1 is released](https://github.com/dashpay/platform/releases/tag/v1.1.0), we can go back to installing the latest stable version.

<!-- Replace -->
Preview build: https://dash-docs-platform--76.org.readthedocs.build/en/76/
<!-- Replace -->
