### PR TITLE
docs: add warnings about the js sdk

### DIFF
--- a/docs/sdk-js/overview.md
+++ b/docs/sdk-js/overview.md
@@ -12,8 +12,9 @@
 Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)
 
 :::{warning}
-The JavaScript SDK provides easy access to Dash Platform without requiring a full node;
-however, it **_does not support Dash Platform's proofs_**. Therefore, it is less secure than the
+The JavaScript SDK should only be used in production when connected to trusted nodes. While it
+provides easy access to Dash Platform without requiring a full node, it **_does not support Dash
+Platform's proofs or verify synchronized blockchain data_**. Therefore, it is less secure than the
 [Rust SDK](../sdk-rs/overview.md), which requests proofs for all queried data.
 :::
 

--- a/docs/sdk-js/overview.md
+++ b/docs/sdk-js/overview.md
@@ -11,6 +11,12 @@
 
 Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)
 
+:::{warning}
+The JavaScript SDK provides easy access to Dash Platform without requiring a full node;
+however, it **_does not support Dash Platform's proofs_**. Therefore, it is less secure than the
+[Rust SDK](../sdk-rs/overview.md), which requests proofs for all queried data.
+:::
+
 Dash library provides access via [DAPI](../explanations/dapi.md) to use both the Dash Core network and Dash Platform on [supported networks](https://github.com/dashpay/platform/#supported-networks). The Dash Core network can be used to broadcast and receive payments. Dash Platform can be used to manage identities, register data contracts for applications, and submit or retrieve application data via documents.
 
 ## Install

--- a/docs/tutorials/connecting-to-testnet.md
+++ b/docs/tutorials/connecting-to-testnet.md
@@ -26,7 +26,7 @@ npm install dash
 
 ### 2. Connect to Dash Platform
 
-:::{attention}
+:::{tip}
 The JavaScript Dash SDK connects to testnet by default. Mainnet can only be accessed by [connecting via address](#connect-via-address).
 :::
 

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -6,11 +6,13 @@
 
 The tutorials in this section walk through the steps necessary to begin building on Dash Platform using the Dash JavaScript SDK. As all communication happens via the masternode hosted decentralized API (DAPI), you can begin using Dash Platform immediately without running a local blockchain node.
 
-Building on Dash Platform requires first registering an Identity and then registering a Data Contract describing the schema of data to be stored. Once that is done, data can be stored and updated by submitting Documents that comply with the Data Contract.
-
-:::{tip}
-You can clone a repository containing the code for all tutorials from <a href="https://github.com/dashpay/platform-readme-tutorials#readme" target="_blank">GitHub</a> or download it as a [zip file](https://github.com/dashpay/platform-readme-tutorials/archive/refs/heads/main.zip).
+:::{warning}
+Only the JavaScript SDK provides easy access to Dash Platform without requiring a full node;
+however, it **_does not support Dash Platform's proofs_**. Therefore, it is less secure than the
+[Rust SDK](../sdk-rs/overview.md), which requests proofs for all queried data.
 :::
+
+Building on Dash Platform requires first registering an Identity and then registering a Data Contract describing the schema of data to be stored. Once that is done, data can be stored and updated by submitting Documents that comply with the Data Contract.
 
 ## Prerequisites
 
@@ -21,6 +23,10 @@ The tutorials in this section are written in JavaScript and use [Node.js](https:
 - The Dash JavaScript SDK (see [Connecting to a Network](../tutorials/connecting-to-testnet.md#1-install-the-dash-sdk))
 
 ## Quickstart
+
+:::{tip}
+You can clone a repository containing the code for all tutorials from <a href="https://github.com/dashpay/platform-readme-tutorials#readme" target="_blank">GitHub</a> or download it as a [zip file](https://github.com/dashpay/platform-readme-tutorials/archive/refs/heads/main.zip).
+:::
 
 While going through each tutorial is advantageous, the subset of tutorials listed below get you from a start to storing data on Dash Platform most quickly:
 

--- a/docs/tutorials/setup-sdk-client.md
+++ b/docs/tutorials/setup-sdk-client.md
@@ -1,8 +1,9 @@
 # Setup SDK Client
 
 :::{warning}
-The JavaScript SDK provides easy access to Dash Platform without requiring a full node;
-however, it **_does not support Dash Platform's proofs_**. Therefore, it is less secure than the
+The JavaScript SDK should only be used in production when connected to trusted nodes. While it
+provides easy access to Dash Platform without requiring a full node, it **_does not support Dash
+Platform's proofs or verify synchronized blockchain data_**. Therefore, it is less secure than the
 [Rust SDK](../sdk-rs/overview.md), which requests proofs for all queried data.
 :::
 

--- a/docs/tutorials/setup-sdk-client.md
+++ b/docs/tutorials/setup-sdk-client.md
@@ -1,5 +1,11 @@
 # Setup SDK Client
 
+:::{warning}
+The JavaScript SDK provides easy access to Dash Platform without requiring a full node;
+however, it **_does not support Dash Platform's proofs_**. Therefore, it is less secure than the
+[Rust SDK](../sdk-rs/overview.md), which requests proofs for all queried data.
+:::
+
 In this tutorial we will show how to configure the client for use in the remaining tutorials.
 
 ## Prerequisites
@@ -10,7 +16,7 @@ In this tutorial we will show how to configure the client for use in the remaini
 
 ## Code
 
-:::{attention}
+:::{tip}
 The JavaScript Dash SDK connects to testnet by default. Mainnet can only be accessed by [connecting via address](./connecting-to-testnet.md#connect-to-a-network).
 :::
 


### PR DESCRIPTION
Since it doesn't request proofs it's less secure than it could be otherwise

<!-- Replace -->
Preview build: https://dash-docs-platform--79.org.readthedocs.build/en/79/
<!-- Replace -->
