### PR TITLE
docs: add note about masternode identities to getIdentityByPublicKeyHash

### DIFF
--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -725,6 +725,10 @@ grpcurl -proto protos/platform/v0/platform.proto \
 
 **Returns**: An [identity](../explanations/identity.md) associated with the provided public key hash
 
+:::{note}
+This endpoint only works for unique keys. Since masternode keys do not have to be unique (e.g. voting keys), some masternode identities cannot be retrieved using this endpoint.
+:::
+
 **Parameters**:
 
 | Name    | Type    | Required | Description |


### PR DESCRIPTION
Some identity keys are not unique and cannot be used to retrieve an identity (since there may be multiple identities using the same key). Related to dashpay/platform#2244.