### PR TITLE
feat: add alternate analytics config

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -28,6 +28,7 @@ extensions = [
   'sphinx.ext.autodoc',
   'sphinx_copybutton',
   'sphinx_design',
+  'sphinxcontrib.googleanalytics',  
   'sphinx.ext.intersphinx',
 ]
 
@@ -144,6 +145,11 @@ html_context = {
     "github_version": "1.0.0",
     "doc_path": "",
 }
+
+# -- Google analytics config ----------------------------------------------
+
+googleanalytics_id = 'G-B3JNYGTPR0'
+googleanalytics_enabled = True
 
 def setup(app):
     app.add_js_file('js/pydata-search-close.js')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ myst-parser==2.0.0
 pydata-sphinx-theme==0.14.4
 pytz==2022.7
 sphinx==7.2.6
+sphinxcontrib-googleanalytics==0.4
 sphinx-copybutton==0.5.2
 sphinx-hoverxref==1.3.0
 sphinx_design==0.5.0


### PR DESCRIPTION
Readthedocs removed their analytics integration (see https://github.com/readthedocs/readthedocs.org/issues/9530#issuecomment-2233541583). This PR introduces use of an addon to re-enable that capability.