### PR TITLE
chore: update hoverxref and sphinx-design dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ pytz==2022.7
 sphinx==7.2.6
 sphinxcontrib-googleanalytics==0.4
 sphinx-copybutton==0.5.2
-sphinx-hoverxref==1.3.0
-sphinx_design==0.5.0
+sphinx-hoverxref==1.4.2
+sphinx_design==0.6.1
 jinja2==3.1.3


### PR DESCRIPTION
- [x] hoverxref - required due to a deprecation: https://about.readthedocs.com/blog/2024/11/embed-api-v2-deprecated/
- [x] sphinx-design