### PR TITLE
docs: update insight testnet urls

### DIFF
--- a/docs/explanations/identity.md
+++ b/docs/explanations/identity.md
@@ -23,7 +23,7 @@ Once an identity is created, its credit balance is used to pay for activity (e.g
 ### Identity Create Process
 
 :::{note}
-On Testnet, a [test Dash faucet](https://insight.testnet.networks.dash.org:3002/insight/) is available. It dispenses small amounts to enable all users to directly acquire the funds necessary to create an identity and username.
+On Testnet, a [test Dash faucet](https://insight.testnet.networks.dash.org/insight/) is available. It dispenses small amounts to enable all users to directly acquire the funds necessary to create an identity and username.
 :::
 
 First, a sponsor (which could be a business, another person, or even the same user who is creating the identity) spends Dash in a transaction to create an invitation. The transaction contains one or more outputs which lock some Dash funds to establish credits within Dash platform.

--- a/docs/index.md
+++ b/docs/index.md
@@ -173,7 +173,7 @@ protocol-ref/errors
 resources/faq
 resources/repository-overview
 Platform Explorer <https://platform-explorer.com/>
-Testnet Block Explorer <https://insight.testnet.networks.dash.org:3002/insight/>
+Testnet Block Explorer <https://insight.testnet.networks.dash.org/insight/>
 Testnet Faucet <http://faucet.testnet.networks.dash.org/>
 JavaScript SDK <https://github.com/dashpay/platform/tree/master/packages/js-dash-sdk#readme>
 resources/source-code

--- a/docs/intro/testnet.md
+++ b/docs/intro/testnet.md
@@ -12,7 +12,7 @@ Testnet is the Dash testing network used for experimentation and evaluation of D
 
 Dash Core Group provides the core Testnet infrastructure consisting of 150 masternodes running Dash Core along with the platform services that provide the [decentralized API (DAPI)](../explanations/dapi.md) and [storage (Drive)](../explanations/drive.md) functionality.
 
-Testnet also includes a [block explorer](https://insight.testnet.networks.dash.org:3002/insight/) for the core blockchain and a [test Dash faucet](http://faucet.testnet.networks.dash.org/) that dispenses funds to users/developers experimenting on the network.
+Testnet also includes a [block explorer](https://insight.testnet.networks.dash.org/insight/) for the core blockchain and a [test Dash faucet](http://faucet.testnet.networks.dash.org/) that dispenses funds to users/developers experimenting on the network.
 
 ### Features
 

--- a/docs/tutorials/create-and-fund-a-wallet.md
+++ b/docs/tutorials/create-and-fund-a-wallet.md
@@ -64,4 +64,4 @@ Once we connect, we output the newly generated mnemonic from `client.wallet.expo
 
 # Next Step
 
-Using the [faucet](https://testnet-faucet.dash.org/), send test funds to the "unused address" from the console output. You will need to wait until the funds are confirmed to use them. The [block explorer](https://insight.testnet.networks.dash.org:3002/insight/) can be used to check confirmations.
+Using the [faucet](https://testnet-faucet.dash.org/), send test funds to the "unused address" from the console output. You will need to wait until the funds are confirmed to use them. The [block explorer](https://insight.testnet.networks.dash.org/insight/) can be used to check confirmations.


### PR DESCRIPTION
Testnet insight is now located at https://insight.testnet.networks.dash.org/insight/.

<!-- Replace -->
Preview build: https://dash-docs-platform--95.org.readthedocs.build/en/95/
<!-- Replace -->
