### PR TITLE
docs: add explicit config file location

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,9 @@
 # Required
 version: 2
 
+sphinx:
+   configuration: conf.py
+
 build:
    os: "ubuntu-22.04"
    tools:


### PR DESCRIPTION
Required per https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/