### PR TITLE
chore: update links to core

### DIFF
--- a/_templates/sidebar-main.html
+++ b/_templates/sidebar-main.html
@@ -478,20 +478,20 @@
                 <p aria-level="2" class="caption" role="heading"><span class="caption-text">Core Docs</span></p>
                 <ul class="nav bd-sidenav">
                     <li class="toctree-l1"><a class="reference internal"
-                            href="https://docs.dash.org/projects/core/en/stable/docs/reference/introduction.html">Blockchain
+                            href="https://docs.dash.org/en/stable/docs/core/reference/introduction.html">Blockchain
                             Reference</a></li>
                     <li class="toctree-l1"><a class="reference internal"
-                            href="https://docs.dash.org/projects/core/en/stable/docs/api/remote-procedure-calls.html">API
+                            href="https://docs.dash.org/en/stable/docs/core/api/remote-procedure-calls.html">API
                             Reference</a>
                     </li>
                     <li class="toctree-l1"><a class="reference internal"
-                            href="https://docs.dash.org/projects/core/en/stable/docs/guide/introduction.html">Core
+                            href="https://docs.dash.org/en/stable/docs/core/guide/introduction.html">Core
                             Guides</a></li>
                     <li class="toctree-l1"><a class="reference internal"
-                            href="https://docs.dash.org/projects/core/en/stable/docs/examples/introduction.html">Core
+                            href="https://docs.dash.org/en/stable/docs/core/examples/introduction.html">Core
                             Examples</a></li>
                     <li class="toctree-l1"><a class="reference internal"
-                            href="https://docs.dash.org/projects/core/en/stable/docs/dashcore/wallet-arguments-and-commands.html">Dash
+                            href="https://docs.dash.org/en/stable/docs/core/dashcore/wallet-arguments-and-commands.html">Dash
                             Core Wallet</a></li>
                     </li>
                 </ul>

--- a/conf.py
+++ b/conf.py
@@ -97,7 +97,7 @@ html_sidebars = {
 html_theme_options = {
    "announcement": "This development version of documentation covers unreleased features.<br>See the <a href='https://docs.dash.org/platform'>stable version of the documentation</a> for information about the currently deployed Platform.",
     "external_links": [
-        {"name": "Core docs", "url": "https://docs.dash.org/projects/core/en/stable/docs/index.html"},
+        {"name": "Core docs", "url": "https://docs.dash.org/en/stable/docs/core/index.html"},
         {"name": "User docs", "url": "https://docs.dash.org/"},
         {"name": "Dash.org", "url": "https://www.dash.org"},
         {"name": "Forum", "url": "https://www.dash.org/forum"},

--- a/docs/dapi-client-js/usage/core/broadcasttransaction.md
+++ b/docs/dapi-client-js/usage/core/broadcasttransaction.md
@@ -14,4 +14,4 @@ Parameters:
 
 Returns : transactionId (string).
 
-N.B : The TransactionID provided is subject to [transaction malleability](https://docs.dash.org/projects/core/en/stable/docs/guide/transactions-transaction-malleability.html), and is not a source of truth (the transaction might be included in a block with a different txid).
+N.B : The TransactionID provided is subject to [transaction malleability](https://docs.dash.org/en/stable/docs/core/guide/transactions-transaction-malleability.html), and is not a source of truth (the transaction might be included in a block with a different txid).

--- a/docs/intro/what-is-dash.md
+++ b/docs/intro/what-is-dash.md
@@ -36,7 +36,7 @@ However, the Dash network has a second layer of network participants that provid
 
 ### Long-Living Masternode Quorums
 
-Dash's [long-living masternode quorums](https://docs.dash.org/projects/core/en/stable/docs/guide/dash-features-masternode-quorums.html) (LLMQs) are used to facilitate the operation of masternode-provided features in a decentralized, deterministic way. These LLMQs are deterministic subsets of the overall masternode list that are formed via a [distributed key generation](../reference/glossary.md#distributed-key-generation-dkg) protocol and remain active for long periods of time (e.g. hours to days). The main task of LLMQs is to perform threshold signing of consensus-related messages for features like InstantSend and ChainLocks.
+Dash's [long-living masternode quorums](https://docs.dash.org/en/stable/docs/core/guide/dash-features-masternode-quorums.html) (LLMQs) are used to facilitate the operation of masternode-provided features in a decentralized, deterministic way. These LLMQs are deterministic subsets of the overall masternode list that are formed via a [distributed key generation](../reference/glossary.md#distributed-key-generation-dkg) protocol and remain active for long periods of time (e.g. hours to days). The main task of LLMQs is to perform threshold signing of consensus-related messages for features like InstantSend and ChainLocks.
 
 ### InstantSend
 

--- a/docs/protocol-ref/identity.md
+++ b/docs/protocol-ref/identity.md
@@ -43,7 +43,7 @@ See the [identity implementation in rs-dpp](https://github.com/dashpay/platform/
 
 ### Identity id
 
-The identity `id` is a unique identifier created from the double sha256 hash of the [outpoint](https://docs.dash.org/projects/core/en/stable/docs/resources/glossary.html#outpoint) funding the identity creation. Typically it is displayed using Base58 encoding.
+The identity `id` is a unique identifier created from the double sha256 hash of the [outpoint](https://docs.dash.org/en/stable/docs/core/resources/glossary.html#outpoint) funding the identity creation. Typically it is displayed using Base58 encoding.
 
 `id = base58(sha256(sha256(<identity create funding outpoint>)))`
 
@@ -236,7 +236,7 @@ The InstantSend asset lock proof is used for transactions that have received an 
 | Field       | Type           | Description |
 | ----------- | -------------- | ----------- |
 | type        | integer        | The asset lock proof type (`0` for InstantSend locks) |
-| instantLock | array of bytes | The InstantSend lock ([`islock`](https://docs.dash.org/projects/core/en/stable/docs/reference/p2p-network-instantsend-messages.html#islock)) |
+| instantLock | array of bytes | The InstantSend lock ([`islock`](https://docs.dash.org/en/stable/docs/core/reference/p2p-network-instantsend-messages.html#islock)) |
 | transaction | array of bytes | The asset lock transaction |
 | outputIndex | integer        | Index of the transaction output to be used |
 
@@ -248,7 +248,7 @@ The ChainLock asset lock proof is used for transactions that have note received 
 | --------------------- | -------------- | ----------- |
 | type                  | array of bytes | The type of asset lock proof (`1` for ChainLocks) |
 | coreChainLockedHeight | integer        | Height of the ChainLocked Core block containing the transaction |
-| outPoint              | object         | The  [outpoint](https://docs.dash.org/projects/core/en/stable/docs/resources/glossary.html#outpoint) being used as the asset lock |
+| outPoint              | object         | The  [outpoint](https://docs.dash.org/en/stable/docs/core/resources/glossary.html#outpoint) being used as the asset lock |
 
 ### Identity State Transition Signing
 

--- a/docs/protocol-ref/state-transition.md
+++ b/docs/protocol-ref/state-transition.md
@@ -84,7 +84,7 @@ More detailed information about the `dataContract` object can be found in the [d
 
 | Field           | Type           | Size | Description |
 | --------------- | -------------- | ---- | ----------- |
-| assetLockProof | array of bytes | 36 bytes | Lock [outpoint](https://docs.dash.org/projects/core/en/stable/docs/resources/glossary.html#outpoint) from the layer 1 locking transaction (36 bytes) |
+| assetLockProof | array of bytes | 36 bytes | Lock [outpoint](https://docs.dash.org/en/stable/docs/core/resources/glossary.html#outpoint) from the layer 1 locking transaction (36 bytes) |
 | publicKeys     | array of keys  | Varies | [Public key(s)](../protocol-ref/identity.md#identity-publickeys) associated with the identity (maximum number of keys: `10`) |
 
 More detailed information about the `publicKeys` object can be found in the [identity section](../protocol-ref/identity.md).
@@ -93,7 +93,7 @@ More detailed information about the `publicKeys` object can be found in the [ide
 
 | Field           | Type           | Size | Description |
 | --------------- | -------------- | ---- | ----------- |
-| assetLockProof | array of bytes | 36 bytes | Lock [outpoint](https://docs.dash.org/projects/core/en/stable/docs/resources/glossary.html#outpoint) from the layer 1 locking transaction (36 bytes) |
+| assetLockProof | array of bytes | 36 bytes | Lock [outpoint](https://docs.dash.org/en/stable/docs/core/resources/glossary.html#outpoint) from the layer 1 locking transaction (36 bytes) |
 | identityId     | array of bytes | 32 bytes | An [Identity ID](../protocol-ref/identity.md#identity-id) for the identity receiving the topup (can be any identity) (32 bytes) |
 
 ### Identity Update

--- a/docs/reference/dapi-endpoints-core-grpc-endpoints.md
+++ b/docs/reference/dapi-endpoints-core-grpc-endpoints.md
@@ -391,7 +391,7 @@ Note: The gRPCurl response `transaction` and `blockHash` data are Base64 encoded
 
 ### subscribeToBlockHeadersWithChainLocks
 
-This endpoint helps support simplified payment verification ([SPV](https://docs.dash.org/projects/core/en/stable/docs/guide/operating-modes-simplified-payment-verification-spv.html)) via DAPI by providing access to block headers which can then be used to verify transactions and simplified masternode lists.
+This endpoint helps support simplified payment verification ([SPV](https://docs.dash.org/en/stable/docs/core/guide/operating-modes-simplified-payment-verification-spv.html)) via DAPI by providing access to block headers which can then be used to verify transactions and simplified masternode lists.
 
 **Returns**: streams the requested block header information  
 **Parameters**:

--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -33,7 +33,7 @@ Dash Platform 0.25.16 included a [breaking change that added versioning](https:/
 
 [Masternode identities](../explanations/identity.md#masternode-identities) are created automatically
 by the system based on the [Core masternode registration transaction (protx)
-hash](inv:core:std#ref-txs-proregtx). Masternode identity IDs are created by converting the protx
+hash](inv:user:std#ref-txs-proregtx). Masternode identity IDs are created by converting the protx
 hash to base58. This can be done using an [online base58
 encoder](https://appdevtools.com/base58-encoder-decoder) or through JavaScript using the [bs58
 package](https://www.npmjs.com/package/bs58) as shown below. For gRPCurl, convert the protx hash to

--- a/docs/reference/dapi-endpoints.md
+++ b/docs/reference/dapi-endpoints.md
@@ -135,7 +135,7 @@ The following endpoints provide information about the Core chain.
 | [`getTransaction`](../reference/dapi-endpoints-core-grpc-endpoints.md#gettransaction) | Returns details for the requested transaction |
 | [`subscribeTo` `BlockHeadersWithChainLocks`](../reference/dapi-endpoints-core-grpc-endpoints.md#subscribetoblockheaderswithchainlocks) | Returns the requested block headers along with the associated ChainLocks. |
 | [`subscribeToMasternodeList`](../reference/dapi-endpoints-core-grpc-endpoints.md#subscribetomasternodelist) | *Added in Dash Platform v1.0.0*<br>Returns the full masternode list from the genesis block to the chain tip as the first message and provides update messages with every new block |
-| [`subscribeTo` `TransactionsWithProofs`](../reference/dapi-endpoints-core-grpc-endpoints.md#subscribetotransactionswithproofs) | Returns transactions matching the provided bloom filter along with the associated [`islock` message](https://docs.dash.org/projects/core/en/stable/docs/reference/p2p-network-instantsend-messages.html#islock) and [merkle block](https://docs.dash.org/projects/core/en/stable/docs/reference/p2p-network-data-messages.html#merkleblock) |
+| [`subscribeTo` `TransactionsWithProofs`](../reference/dapi-endpoints-core-grpc-endpoints.md#subscribetotransactionswithproofs) | Returns transactions matching the provided bloom filter along with the associated [`islock` message](https://docs.dash.org/en/stable/docs/core/reference/p2p-network-instantsend-messages.html#islock) and [merkle block](https://docs.dash.org/en/stable/docs/core/reference/p2p-network-data-messages.html#merkleblock) |
 
 :::{note}
 The previous version of documentation can be [viewed

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -90,7 +90,7 @@ An organization where decision making is governed according to a set of rules th
 
 ## Devnet
 
-A development environment in which developers can obtain and spend Dash that has no real-world value on a network that is very similar to the Dash [mainnet](#mainnet). Multiple independent devnets can coexist without interference. Devnets can be either public or private networks. See the <a href="https://docs.dash.org/projects/core/en/stable/docs/examples/testing-applications.html" target="_blank">Testing Applications page</a> for a more detailed description of network types.
+A development environment in which developers can obtain and spend Dash that has no real-world value on a network that is very similar to the Dash [mainnet](#mainnet). Multiple independent devnets can coexist without interference. Devnets can be either public or private networks. See the <a href="https://docs.dash.org/en/stable/docs/core/examples/testing-applications.html" target="_blank">Testing Applications page</a> for a more detailed description of network types.
 
 ## Direct Settlement Payment Channel (DSPC)
 
@@ -160,7 +160,7 @@ BLS signature resulting from some agreement within a masternode quorum
 
 ## Regtest
 
-A local regression testing environment in which developers can almost instantly generate blocks on demand for testing events, and can create private Dash with no real-world value. See the <a href="https://docs.dash.org/projects/core/en/stable/docs/examples/testing-applications.html" target="_blank">Testing Applications page</a> for a more detailed description of network types.
+A local regression testing environment in which developers can almost instantly generate blocks on demand for testing events, and can create private Dash with no real-world value. See the <a href="https://docs.dash.org/en/stable/docs/core/examples/testing-applications.html" target="_blank">Testing Applications page</a> for a more detailed description of network types.
 
 ## Simple Payment Verification
 
@@ -184,7 +184,7 @@ Dash fork of [Tendermint](https://tendermint.com/core) modified for use in Dash 
 
 ## Testnet
 
-A global testing environment in which developers can obtain and spend Dash that has no real-world value on a network that is very similar to the Dash [mainnet](#mainnet). See the <a href="https://docs.dash.org/projects/core/en/stable/docs/examples/testing-applications.html" target="_blank">Testing Applications page</a> for a more detailed description of network types.
+A global testing environment in which developers can obtain and spend Dash that has no real-world value on a network that is very similar to the Dash [mainnet](#mainnet). See the <a href="https://docs.dash.org/en/stable/docs/core/examples/testing-applications.html" target="_blank">Testing Applications page</a> for a more detailed description of network types.
 
 See: [Intro to Testnet](../intro/testnet.md) for more information
 

--- a/docs/sdk-js/getting-started/core-concepts.md
+++ b/docs/sdk-js/getting-started/core-concepts.md
@@ -1,10 +1,10 @@
 # Core concepts
 
-The [Dash Core Developer Guide](https://docs.dash.org/projects/core/en/stable/docs/guide/introduction.html) will answer most of questions about the fundamentals of Dash. However, some elements provided by the SDK need to be grasped, so we will quickly cover some of those.
+The [Dash Core Developer Guide](https://docs.dash.org/en/stable/docs/core/guide/introduction.html) will answer most of questions about the fundamentals of Dash. However, some elements provided by the SDK need to be grasped, so we will quickly cover some of those.
 
 ## Wallet
 
-At the core of Dash is the Payment Chain. In order to be able to transact on it, one needs to have a set of [UTXOs](https://docs.dash.org/projects/core/en/stable/docs/guide/block-chain-transaction-data.html) that are controlled by a Wallet instance.
+At the core of Dash is the Payment Chain. In order to be able to transact on it, one needs to have a set of [UTXOs](https://docs.dash.org/en/stable/docs/core/guide/block-chain-transaction-data.html) that are controlled by a Wallet instance.
 
 In order to access your UTXO, you will have to provide a valid mnemonic that will unlock the Wallet and automatically fetch the associated UTXOs.
 


### PR DESCRIPTION
Use the new link in the integrated repo instead of the sub-project link that may eventually be deprecated

<!-- Replace -->
Preview build: https://dash-docs-platform--109.org.readthedocs.build/en/109/
<!-- Replace -->
