### PR TITLE
fix: relocate heading to fix linking issue

### DIFF
--- a/docs/dapi-client-js/overview.md
+++ b/docs/dapi-client-js/overview.md
@@ -2,11 +2,11 @@
 .. _dapi-client-js-index:
 ```
 
+# Overview
+
 :::{attention}
 This documentation is based on the [docs directory in the repository](https://github.com/dashpay/platform/tree/master/packages/js-dapi-client/docs) and may not always reflect recent code changes. For the most up-to-date information, please refer to the latest version of the code.
 :::
-
-# Overview
 
 ## DAPI-Client
 


### PR DESCRIPTION
For some reason the label in the eval-rst doesn't work when followed immediately by the admonition. Relocating the heading fixes it.

<!-- Replace -->
Preview build: https://dash-docs-platform--111.org.readthedocs.build/en/111/
<!-- Replace -->
