### PR TITLE
docs: update previous version links

### DIFF
--- a/_templates/sidebar-main.html
+++ b/_templates/sidebar-main.html
@@ -254,7 +254,7 @@
                 
                 <li class="toctree-l1"><a class="reference internal" href="docs/resources/source-code.html">Source
                                 Code</a></li>
-                <li class="toctree-l1"><a class="reference external" href="https://dashplatform.readme.io/v0.23.0/docs">Previous Version
+                <li class="toctree-l1"><a class="reference external" href="https://docs.dash.org/projects/platform/en/1.0.0/docs/">Previous Version
                                 of Docs</a></li>
                 </ul>
                 <p aria-level="2" class="caption" role="heading"><span class="caption-text">JavaScript SDK</span></p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -180,7 +180,7 @@ Testnet Block Explorer <https://insight.testnet.networks.dash.org/insight/>
 Testnet Faucet <https://faucet.testnet.networks.dash.org/>
 JavaScript SDK <https://github.com/dashpay/platform/tree/master/packages/js-dash-sdk#readme>
 resources/source-code
-Previous Version of Docs <https://docs.dash.org/projects/platform/en/0.25.0/docs/>
+Previous Version of Docs <https://docs.dash.org/projects/platform/en/1.0.0/docs/>
 ```
 
 ```{toctree}

--- a/docs/reference/dapi-endpoints-core-grpc-endpoints.md
+++ b/docs/reference/dapi-endpoints-core-grpc-endpoints.md
@@ -824,7 +824,7 @@ Note: The gRPCurl response `proTxHash` data is Base64 encoded.
 
 ## Deprecated Endpoints
 
-The following endpoints were recently deprecated. See the [previous version of documentation](https://docs.dash.org/projects/platform/en/0.25.0/docs/reference/dapi-endpoints-core-grpc-endpoints.html) for additional information on these endpoints.
+The following endpoints were recently deprecated. See the [previous version of documentation](https://docs.dash.org/projects/platform/en/1.0.0/docs/reference/dapi-endpoints-core-grpc-endpoints.html) for additional information on these endpoints.
 
 ### getStatus
 

--- a/docs/reference/dapi-endpoints-json-rpc-endpoints.md
+++ b/docs/reference/dapi-endpoints-json-rpc-endpoints.md
@@ -225,7 +225,7 @@ puts response.read_body
 ## Deprecated Endpoints
 
 The following endpoints were recently deprecated. See the [previous version of this
-documentation](https://docs.dash.org/projects/platform/en/0.25.0/docs/reference/dapi-endpoints-json-rpc-endpoints.html)
+documentation](https://docs.dash.org/projects/platform/en/1.0.0/docs/reference/dapi-endpoints-json-rpc-endpoints.html)
 for older references.
 
 ### getMnListDiff

--- a/docs/reference/dapi-endpoints-platform-endpoints.md
+++ b/docs/reference/dapi-endpoints-platform-endpoints.md
@@ -3515,7 +3515,7 @@ grpcurl -proto protos/platform/v0/platform.proto \
 
 ## Deprecated Endpoints
 
-The following endpoints were recently deprecated. See the [previous version of documentation](https://docs.dash.org/projects/platform/en/0.25.0/docs/reference/dapi-endpoints-platform-endpoints.html) for additional information on these endpoints.
+The following endpoints were recently deprecated. See the [previous version of documentation](https://docs.dash.org/projects/platform/en/1.0.0/docs/reference/dapi-endpoints-platform-endpoints.html) for additional information on these endpoints.
 
 ### getIdentities
 


### PR DESCRIPTION
Switch links to point to v1 of the docs

<!-- Replace -->
Preview build: https://dash-docs-platform--116.org.readthedocs.build/en/116/
<!-- Replace -->
