### PR TITLE
docs: update non-tutorial Platform docs against current public repos

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -35,10 +35,14 @@ extensions = [
 templates_path = ['_templates']
 exclude_patterns = [
     '_build',
+    '.venv',
+    'venv',
     'Thumbs.db',
     '.DS_Store',
     'README.md',
+    'CLAUDE.md',
     '.devcontainer',
+    '.codex',
     '.local',
     'scripts',
     'img/dev/gifs/README.md',

--- a/docs/explanations/dpns.md
+++ b/docs/explanations/dpns.md
@@ -67,7 +67,8 @@ After voting ends, the name is either awarded to one of the identities or locked
 Assuming masternodes do not vote to lock, the identity receiving the most votes takes ownership of the name. However, if the vote locks the name, no identity receives it. If only one identity requests the name, they will receive it even if no masternodes vote.
 
 :::{note}
-Locked names can no longer be requested or awarded in Dash Platform v1, but the plan is to change this in future updates.
+Locked-name handling is part of the current DPNS ruleset, but the exact policy can evolve with
+future Platform releases and governance decisions.
 :::
 
 ### Implementation

--- a/docs/explanations/dpns.md
+++ b/docs/explanations/dpns.md
@@ -67,8 +67,7 @@ After voting ends, the name is either awarded to one of the identities or locked
 Assuming masternodes do not vote to lock, the identity receiving the most votes takes ownership of the name. However, if the vote locks the name, no identity receives it. If only one identity requests the name, they will receive it even if no masternodes vote.
 
 :::{note}
-Locked-name handling is part of the current DPNS ruleset, but the exact policy can evolve with
-future Platform releases and governance decisions.
+Locked names cannot currently be re-requested or awarded. This policy may be revisited in future Platform releases.
 :::
 
 ### Implementation

--- a/docs/explanations/fees.md
+++ b/docs/explanations/fees.md
@@ -16,7 +16,8 @@ Fees on Dash Platform are divided into two main categories:
 Storage fees cover the costs to store the various types of data throughout the network, while processing fees cover the computational costs incurred by the masternodes to process state transitions. For everyday use, processing fees are minuscule compared to storage fees. However, they are important in the prevention of attacks on the network, in which case they become prohibitively expensive.
 
 :::{tip}
-Comprehensive details regarding fees will be available in an upcoming *Dash Platform Fee System* DIP.
+For the implementation-level constants and limits currently used by Platform, see the
+[protocol constants reference](../protocol-ref/protocol-constants.md).
 :::
 
 ## Costs
@@ -46,7 +47,7 @@ Given fluctuations of the Dash price, a variable *Fee Multiplier* provides a way
     feePaid = initialFee * feeMultiplier
 ```
 
-The Fee Multiplier is subject to change at any time at the discretion of the masternodes via a voting mechanism. Dash Core Group research indicates maintaining fees at approximately 2x the cost of hosting the network is optimal.
+The Fee Multiplier is subject to change at any time via network governance and protocol updates.
 
 <!-- Uncomment once link available
 An in-depth look at the Fee Multiplier can be found at **link**
@@ -58,7 +59,8 @@ In an attempt to minimize Dash Platform's storage requirements, users are incent
 
 ## User Tip
 
-Wallets will be enabled to give users the option to provide a tip to the block proposer in hopes of incentivizing them to include their state transition in the next block. This feature will be especially useful in times of high traffic.
+Platform supports a user tip component that can be used to incentivize inclusion of a state
+transition in the next block, especially during periods of high traffic.
 
 ## Formula
 

--- a/docs/explanations/platform-protocol.md
+++ b/docs/explanations/platform-protocol.md
@@ -42,14 +42,13 @@ For additional detail, see the [State Transition](../explanations/platform-proto
 
 ## Versions
 
-| Version | Information |
-| :------ | :---------- |
-| 0.25    | See details in the [GitHub release](https://github.com/dashpay/platform/releases/tag/v0.25.0). |
-| 0.24    | See details in the [GitHub release](https://github.com/dashpay/platform/releases/tag/v0.24.0). |
-| 0.23    | See details in the [GitHub release](https://github.com/dashpay/platform/releases/tag/v0.23.0). |
-| 0.22    | See details in the [GitHub release](https://github.com/dashpay/platform/releases/tag/v0.22.0). |
-| 0.21    | See details in the [GitHub release](https://github.com/dashevo/js-dpp/releases/tag/v0.21.0). |
-| 0.20    | This release updated to a newer version of JSON Schema (2020-12 spec) and also switched to a new regex module ([Re2](https://github.com/google/re2)) for improved security. See more details in the [GitHub release](https://github.com/dashevo/js-dpp/releases/tag/v0.20.0). |
+Platform Protocol evolves together with the public Dash Platform codebase. For the latest
+implementation details and release history, see the
+[Dash Platform monorepo](https://github.com/dashpay/platform) and the project's release notes.
+
+Older version-specific notes that referenced pre-mainnet releases have been removed from this page
+because they no longer reflect the current public Platform state as clearly as the source
+repositories do.
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/explanations/platform-protocol.md
+++ b/docs/explanations/platform-protocol.md
@@ -44,7 +44,8 @@ For additional detail, see the [State Transition](../explanations/platform-proto
 
 Platform Protocol evolves together with the public Dash Platform codebase. For the latest
 implementation details and release history, see the
-[Dash Platform monorepo](https://github.com/dashpay/platform) and the project's release notes.
+[Dash Platform monorepo](https://github.com/dashpay/platform) and the
+[GitHub releases page](https://github.com/dashpay/platform/releases).
 
 Older version-specific notes that referenced pre-mainnet releases have been removed from this page
 because they no longer reflect the current public Platform state as clearly as the source

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,15 @@
 # Platform docs
 
 Welcome to the Dash Platform developer documentation. You'll find guides and documentation to help
-you start working with Dash Platform and building decentralized applications based on the Dash
-cryptocurrency. Let's jump right in!
+you start working with Dash Platform and building decentralized applications on Dash. This site
+focuses on the developer-facing concepts, tutorials, and API references for working with Platform's
+public network and open-source tooling.
+
+:::{note}
+Looking for the current source tree or lower-level implementation details? See the
+[Dash Platform monorepo](https://github.com/dashpay/platform) and the
+[Dash Platform Book](https://dashpay.github.io/platform/).
+:::
 
 ```{eval-rst}
 .. grid:: 1 2 3 3
@@ -26,8 +33,8 @@ cryptocurrency. Let's jump right in!
         :link-type: ref
         :link: tutorials-intro
         
-        Basics of building with Dash Platform
-        
+        Hands-on guides for connecting to Platform and submitting data
+
         +++
         :ref:`Click to begin <tutorials-intro>`
 
@@ -157,6 +164,8 @@ protocol-ref/errors
 
 resources/faq
 resources/repository-overview
+Dash Platform Monorepo <https://github.com/dashpay/platform>
+Dash Platform Book <https://dashpay.github.io/platform/>
 Platform Bridge <https://bridge.thepasta.org/>
 Platform Explorer <https://platform-explorer.com/>
 Testnet Block Explorer <https://insight.testnet.networks.dash.org/insight/>

--- a/docs/intro/what-is-dash-platform.md
+++ b/docs/intro/what-is-dash-platform.md
@@ -4,7 +4,21 @@
 
 # What is Dash Platform
 
-Dash Platform is a [Web3](https://en.wikipedia.org/wiki/Web3) technology stack for building decentralized applications on the Dash network. The two main architectural components, [Drive](../explanations/drive.md) and [DAPI](../explanations/dapi.md), turn the Dash P2P network into a cloud that developers can integrate with their applications.
+Dash Platform is a [Web3](https://en.wikipedia.org/wiki/Web3) technology stack for building
+decentralized applications on the Dash network. It is best understood as a decentralized data
+storage and application layer on top of Dash: developers define schemas and submit structured state
+transitions instead of deploying arbitrary user-written code on-chain.
+
+Its core components, [Drive](../explanations/drive.md) and [DAPI](../explanations/dapi.md),
+provide structured data storage, identity primitives, rich queries, and verifiable data access on
+top of the Dash network.
+
+:::{tip}
+Dash Platform is developed in the open. For the current implementation details, package layout, and
+build instructions, see the [Dash Platform monorepo](https://github.com/dashpay/platform). For a
+broader architectural walkthrough of the Rust codebase, see the
+[Dash Platform Book](https://dashpay.github.io/platform/).
+:::
 
 ```{eval-rst}
 .. raw:: html
@@ -18,19 +32,23 @@ Dash Platform is a [Web3](https://en.wikipedia.org/wiki/Web3) technology stack f
 
 ### Decentralized Cloud Storage
 
-Store your application data in the safest place on the Internet. All data stored on the Dash network is protected by Dash's consensus algorithm, ensuring data integrity and availability.
+Store structured application data on the Dash network with consensus-backed integrity and
+availability.
 
 ### Reduced Data Silos
 
-Because your application data is stored across many nodes on the Dash network, it is safe and always available for customers, business partners, and investors.
+Because application data is stored across the Dash masternode network, it can be shared and queried
+without relying on a single hosted backend.
 
 ### Client Libraries
 
-Write code and integrate with Dash Platform using the languages that matter to your business. Don't worry about understanding blockchain infrastructure: a growing number of client libraries abstract away the complexity typically associated with working on blockchain-based networks.
+Write code and integrate with Dash Platform using client libraries that abstract away much of the
+underlying blockchain and networking complexity.
 
 ### Instant Data Confirmation
 
-Unlike many blockchain-based networks, data stored on the platform is instantly confirmed by the Dash consensus algorithm to ensure the best user experience for users. With Dash Platform, you can gain the advantages of a blockchain-based storage network without the usual UX compromises.
+Unlike many blockchain-based networks, Platform is designed for fast finality and proof-based data
+verification, making it practical for light clients and user-facing applications.
 
 ```{eval-rst}
 .. figure:: ../../img/join-community.svg
@@ -48,12 +66,15 @@ DAPI is a _decentralized_ HTTP API exposing [JSON-RPC](https://www.jsonrpc.org/)
 
 DAPI provides developers the same access and security as running their own Dash node without the cost and maintenance overhead. Unlike traditional APIs which have a single point of failure, DAPI allows clients to connect to different instances depending on resource availability in the Dash network.
 
-Developers can connect to DAPI directly or use a client library. This initial client library, dapi-client, is a relatively simple API wrapper developed by Dash Core Group to provide function calls to the DAPI endpoints.
+Developers can connect to DAPI directly or use higher-level SDKs and client libraries maintained in
+the Dash Platform monorepo. These libraries handle connection management, data serialization, and
+common application workflows. A major design goal of Platform is that clients can verify responses
+with proofs rather than trusting the node that served them.
 
-The source for both DAPI and dapi-client are available on GitHub:
+The source for these components is available on GitHub:
 
-- DAPI: <https://github.com/dashpay/platform/tree/master/packages/dapi>
-- DAPI-Client: <https://github.com/dashpay/platform/tree/master/packages/js-dapi-client>
+- Platform monorepo: <https://github.com/dashpay/platform>
+- Rust SDK docs in this site: [Rust SDK](../sdk-rs/overview.md)
 
 ### Drive - Decentralized Storage
 
@@ -63,4 +84,4 @@ Data created by users of the application is validated and verified against this 
 
 The source is available on GitHub:
 
-- Drive: <https://github.com/dashpay/platform/tree/master/packages/rs-drive>
+- Drive: <https://github.com/dashpay/platform>

--- a/docs/intro/what-is-dash-platform.md
+++ b/docs/intro/what-is-dash-platform.md
@@ -42,8 +42,7 @@ without relying on a single hosted backend.
 
 ### Client Libraries
 
-Write code and integrate with Dash Platform using client libraries that abstract away much of the
-underlying blockchain and networking complexity.
+Write code and integrate with Dash Platform using the languages that matter to your business. Don't worry about understanding blockchain infrastructure: a growing number of client libraries abstract away the complexity typically associated with working on blockchain-based networks.
 
 ### Instant Data Confirmation
 
@@ -74,7 +73,6 @@ with proofs rather than trusting the node that served them.
 The source for these components is available on GitHub:
 
 - Platform monorepo: <https://github.com/dashpay/platform>
-- Rust SDK docs in this site: [Rust SDK](../sdk-rs/overview.md)
 
 ### Drive - Decentralized Storage
 
@@ -84,4 +82,4 @@ Data created by users of the application is validated and verified against this 
 
 The source is available on GitHub:
 
-- Drive: <https://github.com/dashpay/platform>
+- Drive: <https://github.com/dashpay/platform/tree/master/packages/rs-drive>

--- a/docs/reference/platform-proofs.md
+++ b/docs/reference/platform-proofs.md
@@ -4,9 +4,9 @@
 
 # Platform Proofs
 
->❗️ Platform v0.22.0
->
-> Note: As part of the transition from MongoDB to Dash's [GroveDB](https://github.com/dashpay/grovedb), proofs will be not be available for at least the initial version of Platform v0.22.
+Platform proofs are an important part of Dash Platform's trust model. When a response is requested
+with `prove: true`, Platform can return proof data that allows clients to verify that the response
+matches consensus state.
 
 Since data verification is a critical aspect of Dash Platform, all [Platform endpoints](../reference/dapi-endpoints-platform-endpoints.md) can provide an optional proof that the response is correct. Set the optional `prove` parameter (`"prove": true`) in the request to receive a proof that contains the requested data.
 
@@ -57,9 +57,10 @@ Dash Platform 0.21.0 introduced updates to support returning multiple store tree
 - `documentsProof`
 - `stateTransitionProof`
 
-> 🚧
->
-> Dash Platform 0.21.0 introduced a 4 byte [protocol version](https://github.com/dashevo/js-dpp/pull/325) that is prepended to the binary format and is not part of the CBOR-encoded data. When parsing proofs it is necessary to exclude these bytes before decoding the returned data with CBOR.
+:::{note}
+Some proof payloads include a 4-byte protocol version prefix that is not part of the CBOR-encoded
+value. When decoding those values, strip the version prefix before CBOR decoding.
+:::
 
 #### Structure
 

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -18,10 +18,11 @@ Dash Platform has numerous significant advantages, including:
   API](../explanations/dapi.md).
 - Verifiable data: Efficient [GroveDB proofs](https://www.grovedb.org/) for query responses provide
   transparent data integrity.
+- Open development: Core Platform components, SDKs, and tooling are developed in public repos and
+  can be inspected directly.
 
-Although the current feature set covers many use cases, future versions will include features like
-smart contracts to make it even more competitive and directly comparable with projects like
-Ethereum, etc.
+The current feature set already supports identities, names, structured application data, proofs,
+and related developer tooling. New capabilities continue to ship in ongoing releases.
 
 :::
 
@@ -31,8 +32,9 @@ It already is! Dash Platform [launched on
 mainnet](https://www.dash.org/news/dash-evolution-v1-0-0-release-announcement/) in Q3 2024 and has
 had multiple releases since then to add features such as [NFTs](../explanations/nft.md).
 
-The next major release, v2.0, includes a flexible token system. Multiple teams are working to
-improve the SDK experience so developers can more easily get to work building their applications.
+To see the current code and implementation work, check the
+[Dash Platform repository](https://github.com/dashpay/platform) and the
+[Dash Platform Book](https://dashpay.github.io/platform/).
 
 :::
 
@@ -45,13 +47,11 @@ Dash Platform Name Service (DPNS).
 
 :::{dropdown} How can I register a name?
 
-Currently, names can be registered using several technical tools; however, the upcoming [DashPay
-Android](https://play.google.com/store/apps/details?id=hashengineering.darkcoin.wallet) update will
-provide a much easier way to do this.
-
+Currently, names can be registered using several technical tools and compatible applications.
 Developers and other technical users may want to experiment with registering names using the [JS
-SDK](https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-a-name-for-an-identity.html)
-or [Platform TUI](https://github.com/dashpay/platform-tui/).
+SDK](https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-a-name-for-an-identity.html),
+[Platform TUI](https://github.com/dashpay/platform-tui/), or other tools built on the public
+Platform APIs.
 :::
 
 ::::{dropdown} Can I register multiple names?

--- a/docs/resources/faq.md
+++ b/docs/resources/faq.md
@@ -33,8 +33,7 @@ mainnet](https://www.dash.org/news/dash-evolution-v1-0-0-release-announcement/) 
 had multiple releases since then to add features such as [NFTs](../explanations/nft.md).
 
 To see the current code and implementation work, check the
-[Dash Platform repository](https://github.com/dashpay/platform) and the
-[Dash Platform Book](https://dashpay.github.io/platform/).
+[Dash Platform repository](https://github.com/dashpay/platform).
 
 :::
 
@@ -47,11 +46,8 @@ Dash Platform Name Service (DPNS).
 
 :::{dropdown} How can I register a name?
 
-Currently, names can be registered using several technical tools and compatible applications.
-Developers and other technical users may want to experiment with registering names using the [JS
-SDK](https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-a-name-for-an-identity.html),
-[Platform TUI](https://github.com/dashpay/platform-tui/), or other tools built on the public
-Platform APIs.
+Currently, names can be registered using the [DashPay Android wallet](https://play.google.com/store/apps/details?id=hashengineering.darkcoin.wallet).
+Developers and other technical users may want to experiment with registering names using the [Dash Evo Tool](https://github.com/dashpay/dash-evo-tool) or the [JavaScript SDK](https://docs.dash.org/projects/platform/en/stable/docs/tutorials/identities-and-names/register-a-name-for-an-identity.html).
 :::
 
 ::::{dropdown} Can I register multiple names?

--- a/docs/resources/repository-overview.md
+++ b/docs/resources/repository-overview.md
@@ -18,21 +18,10 @@ layout can change over time, so treat the monorepo as the source of truth.
 
 | Component | Description |
 | - | - |
-| JavaScript SDK | JavaScript tooling for connecting to Platform, creating identities, and submitting state transitions |
-| Rust SDK (`rs-sdk`) | Rust-first SDK for building applications and verifying Platform data |
-| FFI / mobile SDK layers | Shared components used for Swift and other native integrations |
-| WASM bindings | WebAssembly-oriented bindings for browser and hybrid environments |
-
-## SDK Availability
-
-The current Platform repository README presents SDK support as follows:
-
-| SDK | Status |
-| - | - |
-| Rust (`rs-sdk`) | Available now |
-| JavaScript (`js-evo-sdk`) | Available now |
-| iOS / Swift | Planned in v3.1 |
-| Android | Planned in v3.2 |
+| [js-evo-sdk](https://github.com/dashpay/platform/tree/master/packages/js-evo-sdk) | JavaScript tooling for connecting to Platform, creating identities, and submitting state transitions |
+| [rs-sdk](https://github.com/dashpay/platform/tree/master/packages/rs-sdk) | Rust-first SDK for building applications and verifying Platform data |
+| [rs-sdk-ffi](https://github.com/dashpay/platform/tree/master/packages/rs-sdk-ffi) / [swift-sdk](https://github.com/dashpay/platform/tree/master/packages/swift-sdk) | Shared components used for Swift and other native integrations |
+| [wasm-sdk](https://github.com/dashpay/platform/tree/master/packages/wasm-sdk) | WebAssembly-oriented bindings for browser and hybrid environments |
 
 ## Platform and Supporting Repositories
 
@@ -40,10 +29,10 @@ These run on the network and process data.
 
 | Component | Description |
 | - | - |
-| DAPI / rs-dapi | Decentralized API server implementations |
-| rs-drive | Drive query and indexing layer over GroveDB |
-| rs-dpp | Dash Platform Protocol (data contracts, documents, state transitions, identities) |
-| dashmate | Node management and local development tool |
+| [dapi](https://github.com/dashpay/platform/tree/master/packages/dapi) / [rs-dapi](https://github.com/dashpay/platform/tree/master/packages/rs-dapi) | Decentralized API server implementations |
+| [rs-drive](https://github.com/dashpay/platform/tree/master/packages/rs-drive) | Drive query and indexing layer over GroveDB |
+| [rs-dpp](https://github.com/dashpay/platform/tree/master/packages/rs-dpp) | Dash Platform Protocol (data contracts, documents, state transitions, identities) |
+| [dashmate](https://github.com/dashpay/platform/tree/master/packages/dashmate) | Node management and local development tool |
 | [rs-tenderdash-abci](https://github.com/dashpay/rs-tenderdash-abci) | Tenderdash ABCI application |
 | [grovedb](https://github.com/dashpay/grovedb) | Hierarchical authenticated data structure |
 | [tenderdash](https://github.com/dashpay/tenderdash) | Byzantine fault-tolerant consensus engine |
@@ -55,8 +44,8 @@ Built-in data contracts used by the network.
 
 | Component | Description |
 | - | - |
-| dashpay-contract | DashPay contract documents JSON Schema |
-| dpns-contract | DPNS contract documents JSON Schema |
+| [dashpay-contract](https://github.com/dashpay/platform/tree/master/packages/dashpay-contract) | DashPay contract documents JSON Schema |
+| [dpns-contract](https://github.com/dashpay/platform/tree/master/packages/dpns-contract) | DPNS contract documents JSON Schema |
 
 ## Source Code Location
 

--- a/docs/resources/repository-overview.md
+++ b/docs/resources/repository-overview.md
@@ -5,19 +5,34 @@
 # Repository Overview
 
 Dash Platform uses a [monorepo](https://en.wikipedia.org/wiki/Monorepo) structure containing most
-packages that comprise Dash Platform. Packages are located in the
-[packages](https://github.com/dashpay/platform/tree/master/packages) directory.
+of the source code that powers the network, SDKs, and development tooling. The public source tree
+is available in the [dashpay/platform](https://github.com/dashpay/platform) repository.
+
+If you want a higher-level architectural walkthrough of the current Rust codebase, see the
+[Dash Platform Book](https://dashpay.github.io/platform/).
 
 ## SDKs
 
-These are the primary tools for developers building on Dash Platform.
+These are the primary tools for developers building on Dash Platform. Package names and exact module
+layout can change over time, so treat the monorepo as the source of truth.
 
 | Component | Description |
 | - | - |
-| [js-evo-sdk](https://github.com/dashpay/platform/tree/master/packages/js-evo-sdk) | JavaScript SDK (`npm install @dashevo/evo-sdk`) |
-| [rs-sdk](https://github.com/dashpay/platform/tree/master/packages/rs-sdk) | Rust SDK for building applications on Dash Platform |
-| [rs-sdk-ffi](https://github.com/dashpay/platform/tree/master/packages/rs-sdk-ffi) / [swift-sdk](https://github.com/dashpay/platform/tree/master/packages/swift-sdk) | FFI layer and iOS/Swift SDK |
-| [wasm-sdk](https://github.com/dashpay/platform/tree/master/packages/wasm-sdk) | WebAssembly bindings for browser-based applications |
+| JavaScript SDK | JavaScript tooling for connecting to Platform, creating identities, and submitting state transitions |
+| Rust SDK (`rs-sdk`) | Rust-first SDK for building applications and verifying Platform data |
+| FFI / mobile SDK layers | Shared components used for Swift and other native integrations |
+| WASM bindings | WebAssembly-oriented bindings for browser and hybrid environments |
+
+## SDK Availability
+
+The current Platform repository README presents SDK support as follows:
+
+| SDK | Status |
+| - | - |
+| Rust (`rs-sdk`) | Available now |
+| JavaScript (`js-evo-sdk`) | Available now |
+| iOS / Swift | Planned in v3.1 |
+| Android | Planned in v3.2 |
 
 ## Platform and Supporting Repositories
 
@@ -25,10 +40,10 @@ These run on the network and process data.
 
 | Component | Description |
 | - | - |
-| [dapi](https://github.com/dashpay/platform/tree/master/packages/dapi) / [rs-dapi](https://github.com/dashpay/platform/tree/master/packages/rs-dapi) | Decentralized API server implementations |
-| [rs-drive](https://github.com/dashpay/platform/tree/master/packages/rs-drive) | Drive query and indexing layer over GroveDB |
-| [rs-dpp](https://github.com/dashpay/platform/tree/master/packages/rs-dpp) | Dash Platform Protocol (data contracts, documents, state transitions, identities) |
-| [dashmate](https://github.com/dashpay/platform/tree/master/packages/dashmate) | Node management and local development tool |
+| DAPI / rs-dapi | Decentralized API server implementations |
+| rs-drive | Drive query and indexing layer over GroveDB |
+| rs-dpp | Dash Platform Protocol (data contracts, documents, state transitions, identities) |
+| dashmate | Node management and local development tool |
 | [rs-tenderdash-abci](https://github.com/dashpay/rs-tenderdash-abci) | Tenderdash ABCI application |
 | [grovedb](https://github.com/dashpay/grovedb) | Hierarchical authenticated data structure |
 | [tenderdash](https://github.com/dashpay/tenderdash) | Byzantine fault-tolerant consensus engine |
@@ -40,8 +55,8 @@ Built-in data contracts used by the network.
 
 | Component | Description |
 | - | - |
-| [dashpay-contract](https://github.com/dashpay/platform/tree/master/packages/dashpay-contract) | DashPay contract documents JSON Schema |
-| [dpns-contract](https://github.com/dashpay/platform/tree/master/packages/dpns-contract) | DPNS contract documents JSON Schema |
+| dashpay-contract | DashPay contract documents JSON Schema |
+| dpns-contract | DPNS contract documents JSON Schema |
 
 ## Source Code Location
 

--- a/docs/sdk-rs/overview.md
+++ b/docs/sdk-rs/overview.md
@@ -6,6 +6,12 @@ based on the Dash Platform Protocol (DPP).
 
 See the [Quick Start page](quick-start.md) for example setup and use of the SDK.
 
+:::{note}
+For the current monorepo layout and lower-level implementation details, see the
+[Dash Platform repository](https://github.com/dashpay/platform) and the
+[Dash Platform Book](https://dashpay.github.io/platform/).
+:::
+
 ## Usage
 
 ### Cargo.toml
@@ -21,16 +27,16 @@ dash-sdk = { git="https://github.com/dashpay/platform" }
 ### Examples
 
 You can inspect tests in the
-[`tests/`](https://github.com/dashpay/platform/tree/v1.0-dev/packages/rs-sdk/tests/) folder for
+[`tests/`](https://github.com/dashpay/platform/tree/master/packages/rs-sdk/tests/) folder for
 detailed examples or see a simple example in the
-[`examples/`](https://github.com/dashpay/platform/tree/v1.0-dev/packages/rs-sdk/examples) folder.
+[`examples/`](https://github.com/dashpay/platform/tree/master/packages/rs-sdk/examples) folder.
 See the [Platform Terminal User Interface (TUI)](https://github.com/dashpay/platform-tui/) for an
 application that uses the SDK to execute various state transitions.
 
-:::{attention}
-SDK documentation will be available on docs.rs once the Dash SDK crate is published. Meanwhile,
-the [pre-release documentation](https://dashpay.github.io/docs-platform/dash_sdk/) is available
-for reference. Please keep in mind that it is incomplete and may be outdated.
+:::{note}
+If you need the latest usage details, examples, or implementation references, prefer the
+[Dash Platform monorepo](https://github.com/dashpay/platform) and the
+[Dash Platform Book](https://dashpay.github.io/platform/) over older hosted snapshots.
 :::
 
 ### Mocking
@@ -39,6 +45,6 @@ The Dash Platform SDK supports mocking through the `mocks` feature which provide
 to define mock expectations and use the SDK without a connection to Platform.
 
 You can see examples of mocking in
-[mock_fetch.rs](https://github.com/dashpay/platform/blob/master/packages/rs-sdk/tests/fetch/mock_fetch.rs)
+[mock_fetch.rs](https://github.com/dashpay/platform/tree/master/packages/rs-sdk/tests/fetch/mock_fetch.rs)
 and
-[mock_fetch_many.rs](https://github.com/dashpay/platform/blob/master/packages/rs-sdk/tests/fetch/mock_fetch_many.rs).
+[mock_fetch_many.rs](https://github.com/dashpay/platform/tree/master/packages/rs-sdk/tests/fetch/mock_fetch_many.rs).

--- a/docs/sdk-rs/overview.md
+++ b/docs/sdk-rs/overview.md
@@ -45,6 +45,6 @@ The Dash Platform SDK supports mocking through the `mocks` feature which provide
 to define mock expectations and use the SDK without a connection to Platform.
 
 You can see examples of mocking in
-[mock_fetch.rs](https://github.com/dashpay/platform/tree/master/packages/rs-sdk/tests/fetch/mock_fetch.rs)
+[mock_fetch.rs](https://github.com/dashpay/platform/blob/master/packages/rs-sdk/tests/fetch/mock_fetch.rs)
 and
-[mock_fetch_many.rs](https://github.com/dashpay/platform/tree/master/packages/rs-sdk/tests/fetch/mock_fetch_many.rs).
+[mock_fetch_many.rs](https://github.com/dashpay/platform/blob/master/packages/rs-sdk/tests/fetch/mock_fetch_many.rs).

--- a/docs/sdk-rs/quick-start.md
+++ b/docs/sdk-rs/quick-start.md
@@ -10,7 +10,7 @@ Several packages are required to use the Dash SDK. Install them by running:
 # Install required packages
 sudo apt-get install clang cmake gcc unzip
 # Install recent protobuf version
-wget https://github.com/protocolbuffers/protobuf/releases/download/v26.1/protoc-26.1-linux-x86_64.zip
+wget https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip
 sudo unzip protoc-*-linux-x86_64.zip -d /usr/local
 ```
 
@@ -41,9 +41,11 @@ You should see the installed version of Rust.
 
 ### Install Dash Core
 
-Currently, the SDK is dependent on a Dash Core full node to support proof verification and provide
-wallet access. Follow the instructions below to install Dash Core and run it on Testnet. **Note:**
-it is possible, although not recommended, to retrieve data from Dash Platform without proof
+The Rust SDK is the best fit when you want proof-aware Platform access and tighter integration with
+the current Rust codebase. Many workflows still assume access to a Dash Core full node for proof
+verification and wallet-related operations. Follow the instructions below to install Dash Core and
+run it on testnet. **Note:** it is possible, although not recommended, to retrieve data from Dash
+Platform without proof verification.
 
 - [Dash Core installation instructions](inv:user:std#dashcore-installation)
 - [Running Dash Core on Testnet](inv:user:std#dashcore-testnet)
@@ -170,10 +172,11 @@ Identity balance: 932523994
 
 ## SDK documentation
 
-:::{attention}
-SDK documentation will be available on docs.rs once the Dash SDK crate is published. Meanwhile,
-the [pre-release documentation](https://dashpay.github.io/docs-platform/dash_sdk/) is available
-for reference. Please keep in mind that it is incomplete and may be outdated.
+:::{note}
+For the current code, examples, and package layout, refer to the
+[Dash Platform monorepo](https://github.com/dashpay/platform) and the
+[Dash Platform Book](https://dashpay.github.io/platform/). Hosted API docs may lag behind the
+latest source changes.
 :::
 
 ## DAPI client example

--- a/docs/sdk-rs/quick-start.md
+++ b/docs/sdk-rs/quick-start.md
@@ -10,7 +10,7 @@ Several packages are required to use the Dash SDK. Install them by running:
 # Install required packages
 sudo apt-get install clang cmake gcc unzip
 # Install recent protobuf version
-wget https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip
+wget https://github.com/protocolbuffers/protobuf/releases/download/v34.1/protoc-34.1-linux-x86_64.zip
 sudo unzip protoc-*-linux-x86_64.zip -d /usr/local
 ```
 

--- a/docs/tutorials/building-platform.md
+++ b/docs/tutorials/building-platform.md
@@ -4,7 +4,14 @@
 
 # Building Dash Platform
 
-The following instructions explain how to create and run a development build of Dash Platform on Ubuntu. The instructions have been tested on Ubuntu 22.04 and 24.04.
+The following instructions explain how to create and run a development build of Dash Platform on
+Ubuntu. The instructions have been tested on Ubuntu 22.04 and 24.04.
+
+:::{important}
+This page tracks the current high-level workflow, but the
+[Dash Platform repository](https://github.com/dashpay/platform) is the source of truth for package
+versions and build changes. If a version here ever conflicts with the repo README, follow the repo.
+:::
 
 ## Install prerequisites
 
@@ -22,20 +29,23 @@ sudo apt install -y build-essential libssl-dev pkg-config clang cmake llvm unzip
 
 ### NodeJS
 
-Install the [Node Version Manager](https://github.com/nvm-sh/nvm) and use it to install NodeJS:
+Install the [Node Version Manager](https://github.com/nvm-sh/nvm) and use it to install Node.js
+v20:
 
 ``` shell
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-nvm install 20.18
+nvm install 20
 ```
 
 ### Docker
 
 :::{warning}
-Only complete the following steps if you do not already have Docker installed. Otherwise, just make sure you have a version that meets the requirements in the [Platform repository README](https://github.com/dashpay/platform?tab=readme-ov-file#how-to-build-and-set-up-a-node-from-the-code-in-this-repo).
+Only complete the following steps if you do not already have Docker installed. Otherwise, just make
+sure you have Docker v20.10 or newer, as described in the
+[Platform repository README](https://github.com/dashpay/platform?tab=readme-ov-file#how-to-build-and-set-up-a-node-from-the-code-in-this-repo).
 :::
 
 ``` shell
@@ -54,7 +64,7 @@ newgrp docker
 ### Protocol buffers
 
 ``` shell
-wget https://github.com/protocolbuffers/protobuf/releases/download/v27.3/protoc-27.3-linux-x86_64.zip
+wget https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip
 sudo unzip protoc-*-linux-x86_64.zip -d /usr/local
 ```
 
@@ -65,13 +75,15 @@ Execute the following script to install Rust. Use the default options during the
 ``` shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 . "$HOME/.cargo/env"
-rustup default 1.85.0
+rustup default stable
+rustup update
+rustup target add wasm32-unknown-unknown
 ```
 
 ### WASM CLI
 
 ``` shell
-cargo install wasm-bindgen-cli@0.2.100
+cargo install wasm-bindgen-cli@0.2.103
 ```
 
 ### Check versions
@@ -84,6 +96,7 @@ docker --version
 docker compose version
 protoc --version
 rustc --version
+wasm-bindgen --version
 ```
 
 ## Configure firewall
@@ -122,6 +135,12 @@ Next, build and complete the initial setup:
 ``` shell
 corepack enable
 yarn setup
+```
+
+After making source changes, rebuild the workspace with:
+
+``` shell
+yarn build
 ```
 
 # Running Dash Platform
@@ -163,6 +182,12 @@ If the node is actively participating in a distributed key generation (DKG) sess
 
 ``` shell
 yarn stop --force
+```
+
+If you rebuilt packages while the local environment was already running, restart it with:
+
+``` shell
+yarn restart
 ```
 
 # Executing tests

--- a/docs/tutorials/building-platform.md
+++ b/docs/tutorials/building-platform.md
@@ -4,14 +4,7 @@
 
 # Building Dash Platform
 
-The following instructions explain how to create and run a development build of Dash Platform on
-Ubuntu. The instructions have been tested on Ubuntu 22.04 and 24.04.
-
-:::{important}
-This page tracks the current high-level workflow, but the
-[Dash Platform repository](https://github.com/dashpay/platform) is the source of truth for package
-versions and build changes. If a version here ever conflicts with the repo README, follow the repo.
-:::
+The following instructions explain how to create and run a development build of Dash Platform on Ubuntu. The instructions have been tested on Ubuntu 22.04 and 24.04.
 
 ## Install prerequisites
 
@@ -29,23 +22,20 @@ sudo apt install -y build-essential libssl-dev pkg-config clang cmake llvm unzip
 
 ### NodeJS
 
-Install the [Node Version Manager](https://github.com/nvm-sh/nvm) and use it to install Node.js
-v20:
+Install the [Node Version Manager](https://github.com/nvm-sh/nvm) and use it to install NodeJS:
 
 ``` shell
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-nvm install 20
+nvm install 20.18
 ```
 
 ### Docker
 
 :::{warning}
-Only complete the following steps if you do not already have Docker installed. Otherwise, just make
-sure you have Docker v20.10 or newer, as described in the
-[Platform repository README](https://github.com/dashpay/platform?tab=readme-ov-file#how-to-build-and-set-up-a-node-from-the-code-in-this-repo).
+Only complete the following steps if you do not already have Docker installed. Otherwise, just make sure you have a version that meets the requirements in the [Platform repository README](https://github.com/dashpay/platform?tab=readme-ov-file#how-to-build-and-set-up-a-node-from-the-code-in-this-repo).
 :::
 
 ``` shell
@@ -64,7 +54,7 @@ newgrp docker
 ### Protocol buffers
 
 ``` shell
-wget https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip
+wget https://github.com/protocolbuffers/protobuf/releases/download/v27.3/protoc-27.3-linux-x86_64.zip
 sudo unzip protoc-*-linux-x86_64.zip -d /usr/local
 ```
 
@@ -75,15 +65,13 @@ Execute the following script to install Rust. Use the default options during the
 ``` shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 . "$HOME/.cargo/env"
-rustup default stable
-rustup update
-rustup target add wasm32-unknown-unknown
+rustup default 1.85.0
 ```
 
 ### WASM CLI
 
 ``` shell
-cargo install wasm-bindgen-cli@0.2.103
+cargo install wasm-bindgen-cli@0.2.100
 ```
 
 ### Check versions
@@ -137,12 +125,6 @@ corepack enable
 yarn setup
 ```
 
-After making source changes, rebuild the workspace with:
-
-``` shell
-yarn build
-```
-
 # Running Dash Platform
 
 Run the following command to start Platform. Occasionally, this command will fail on first run. If it fails, run the command again as needed. If the command consistently fails on the same step, further debugging may be required.
@@ -182,12 +164,6 @@ If the node is actively participating in a distributed key generation (DKG) sess
 
 ``` shell
 yarn stop --force
-```
-
-If you rebuilt packages while the local environment was already running, restart it with:
-
-``` shell
-yarn restart
 ```
 
 # Executing tests

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -4,13 +4,23 @@
 
 # Introduction
 
-The tutorials in this section walk through the steps necessary to begin building on Dash Platform using the Dash JavaScript SDK. As all communication happens via the masternode hosted decentralized API (DAPI), you can begin using Dash Platform immediately without running a local blockchain node.
+The tutorials in this section walk through the steps necessary to begin building on Dash Platform
+using the JavaScript SDK. As all communication happens via the masternode-hosted decentralized API
+(DAPI), you can begin using Dash Platform immediately without running a local blockchain node.
 
 Building on Dash Platform requires first registering an Identity and then registering a Data Contract describing the schema of data to be stored. Once that is done, data can be stored and updated by submitting Documents that comply with the Data Contract.
 
+:::{note}
+These tutorials are intentionally JavaScript-first because they are designed as the quickest path to
+submitting data on Platform. If you are working closer to the current Rust codebase, also see the
+[Rust SDK section](../sdk-rs/overview.md) and the [Dash Platform Book](https://dashpay.github.io/platform/).
+:::
+
 ## Prerequisites
 
-The tutorials in this section are written in JavaScript and use [Node.js](https://nodejs.org/en/about/). The following prerequisites are necessary to complete the tutorials:
+The tutorials in this section are written in JavaScript and use
+[Node.js](https://nodejs.org/en/about/). The following prerequisites are necessary to complete the
+tutorials:
 
 - [Node.js](https://nodejs.org/en/) (v20+)
 - Familiarity with JavaScript asynchronous functions using [async/await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await)

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -4,23 +4,13 @@
 
 # Introduction
 
-The tutorials in this section walk through the steps necessary to begin building on Dash Platform
-using the JavaScript SDK. As all communication happens via the masternode-hosted decentralized API
-(DAPI), you can begin using Dash Platform immediately without running a local blockchain node.
+The tutorials in this section walk through the steps necessary to begin building on Dash Platform using the Dash JavaScript SDK. As all communication happens via the masternode hosted decentralized API (DAPI), you can begin using Dash Platform immediately without running a local blockchain node.
 
 Building on Dash Platform requires first registering an Identity and then registering a Data Contract describing the schema of data to be stored. Once that is done, data can be stored and updated by submitting Documents that comply with the Data Contract.
 
-:::{note}
-These tutorials are intentionally JavaScript-first because they are designed as the quickest path to
-submitting data on Platform. If you are working closer to the current Rust codebase, also see the
-[Rust SDK section](../sdk-rs/overview.md) and the [Dash Platform Book](https://dashpay.github.io/platform/).
-:::
-
 ## Prerequisites
 
-The tutorials in this section are written in JavaScript and use
-[Node.js](https://nodejs.org/en/about/). The following prerequisites are necessary to complete the
-tutorials:
+The tutorials in this section are written in JavaScript and use [Node.js](https://nodejs.org/en/about/). The following prerequisites are necessary to complete the tutorials:
 
 - [Node.js](https://nodejs.org/en/) (v20+)
 - Familiarity with JavaScript asynchronous functions using [async/await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await)


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                            
                                                                                                                                                                                                                        
  Refreshes the user-facing, non-tutorial Platform docs to better match the current public Platform project.                                                                                                            
                                                                                                                                                                                                                        
 This PR keeps the work in `dashpay/docs-platform` and uses the public `dashpay/platform` repo plus the Platform Book as reference material
                                                                                                                                                                                                                        
  ## What changed
                                                                                                                                                                                                                        
  - refreshed the main Platform landing and overview pages                                                                                                                                                              
  - updated the Platform intro to reflect current positioning as a decentralized data storage and application layer on top of Dash                                                                                      
  - added clearer pointers to the public Platform monorepo and Platform Book                                                                                                                                            
  - updated the repository overview to better match the current public package/SDK picture                                                                                                                              
  - refreshed the Rust SDK overview and quick start wording to remove obviously stale pre-release language                                                                                                              
  - updated the Platform Protocol and Platform Proofs pages to remove outdated future/pre-mainnet framing                                                                                                               
  - cleaned up stale future-looking wording in the Fees and DPNS explanation pages
  - updated Sphinx `exclude_patterns` so local workspace artifacts like `.venv/` and `CLAUDE.md` do not get pulled into docs builds                                                                                     
                                                                                                                                                                                                                        
  ## Scope                                                                                                                                                                                                              
                                                                                                                                                                                                                        
  - intentionally limited to non-tutorial pages                                                                                                                                                                         
  - tutorial-specific changes were not included, per the latest guidance in Slack                                                                                                                                       
  - avoided the protocol reference section changes that are already being worked on separately                                                                                                                          
                                                                                                                                                                                                                        
  ## Verification                                                                                                                                                                                                       
                                                                                                                                                                                                                        
  - built locally with `python3 -m sphinx -M html . _build`                                                                                                                                                             
  - HTML build succeeds                                                                                                                                                                                                 


<!-- Replace -->
Preview build: https://dash-docs-platform--139.org.readthedocs.build/en/139/
<!-- Replace -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated platform guides, SDK references, tutorials, and FAQs for clarity and current state
  * Added direct links to the Dash Platform monorepo and Dash Platform Book
  * Clarified platform capabilities (identities, names, structured data, proofs) and removed outdated pre-mainnet/version-specific notes
  * Refined several explanatory pages and proof guidance for clearer developer instructions

* **Chores**
  * Expanded documentation build exclusions to omit local environment and agent-related artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->