### PR TITLE
ci: bump ubuntu, python to match local versions and checkout to latest

### DIFF
--- a/.github/workflows/check-tutorial-sync.yml
+++ b/.github/workflows/check-tutorial-sync.yml
@@ -8,18 +8,18 @@ on:
 
 jobs:
   check-sync:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: dashpay/platform-tutorials
           path: platform-tutorials
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: '3.10'
+          python-version: '3.13'
 
       - run: pip install pyyaml
 

--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -10,10 +10,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: edit-pull-request-description
-        uses: Jerome1337/comment-pull-request@v1.0.4
+        uses: Jerome1337/comment-pull-request@77a1932e3cac02d55e5b9ce108607aaea45663a8 # v1.0.4
 
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Maintenance pass on the two GitHub Actions workflows.

### `check-tutorial-sync.yml`
- Bump runner `ubuntu-22.04` → `ubuntu-24.04`
- Bump `actions/checkout` v6.0.2 → v7.0.0 (both steps)
- Bump `actions/setup-python` v6.2.0 → v6.3.0
- Bump `python-version` `3.10` → `3.13` to match the local development environment

### `preview-url.yml`
- Bump runner `ubuntu-22.04` → `ubuntu-24.04`
- SHA-pin `Jerome1337/comment-pull-request@v1.0.4` to its commit (`77a1932`)