### PR TITLE
docs: surface Evo SDK site and add example-app cards

### DIFF
--- a/_static/css/pydata-overrides.css
+++ b/_static/css/pydata-overrides.css
@@ -151,6 +151,24 @@ tbody tr:nth-child(even) { background-color: var(--table-bg-color-even); }
   border-color: var(--pst-color-primary)
 }
 
+/* Zoom example-app screenshots while keeping the preview viewport unchanged.
+   A 1.4x scale displays roughly half of the source image area. */
+.example-app-card .sd-card-img-top {
+  height: 18rem;
+  object-fit: cover;
+  object-position: left top;
+  transform: scale(1.4);
+  transform-origin: left top;
+  clip-path: inset(0 28.572% 28.572% 0);
+}
+
+@media (max-width: 767.98px) {
+  .example-app-card .sd-card-img-top {
+    height: 75vw;
+    max-height: 28rem;
+  }
+}
+
 /* These are hacks to hide the pydata-theme search popup behind the readthedocs
 sphinx search extension interface.
 */

--- a/docs/index.md
+++ b/docs/index.md
@@ -179,13 +179,14 @@ protocol-ref/errors
 :hidden:
 
 resources/faq
-resources/repository-overview
 Dash Platform Monorepo <https://github.com/dashpay/platform>
-Dash Platform Book <https://dashpay.github.io/platform/>
+resources/repository-overview
 Platform Bridge <https://bridge.thepasta.org/>
 Platform Explorer <https://platform-explorer.com/>
 Testnet Block Explorer <https://insight.testnet.networks.dash.org/insight/>
 Testnet Faucet <https://faucet.testnet.networks.dash.org/>
+Evo SDK Playground <https://evo-sdk.dash.org/playground>
+Dash Platform Book <https://dashpay.github.io/platform/>
 Previous Version of Docs <https://docs.dash.org/projects/platform/en/2.0.0/docs/>
 ```
 

--- a/docs/resources/repository-overview.md
+++ b/docs/resources/repository-overview.md
@@ -23,6 +23,8 @@ layout can change over time, so treat the monorepo as the source of truth.
 | [rs-sdk-ffi](https://github.com/dashpay/platform/tree/master/packages/rs-sdk-ffi) / [swift-sdk](https://github.com/dashpay/platform/tree/master/packages/swift-sdk) | Shared components used for Swift and other native integrations |
 | [wasm-sdk](https://github.com/dashpay/platform/tree/master/packages/wasm-sdk) | WebAssembly-oriented bindings for browser and hybrid environments |
 
+The [Evo SDK site](https://evo-sdk.dash.org/) hosts developer-facing tooling for the JavaScript SDK: an interactive [playground](https://evo-sdk.dash.org/playground.html) that runs read-only queries in the browser against testnet, [SDK documentation](https://evo-sdk.dash.org/docs.html), and an AI reference.
+
 ## Platform and Supporting Repositories
 
 These run on the network and process data.

--- a/docs/tutorials/connecting-to-testnet.md
+++ b/docs/tutorials/connecting-to-testnet.md
@@ -24,6 +24,10 @@ The JavaScript SDK package is available from npmjs.com and can be installed by r
 npm install @dashevo/evo-sdk
 ```
 
+:::{tip}
+Want to try the SDK before installing anything? The [Evo SDK Playground](https://evo-sdk.dash.org/playground) runs queries adapted from these tutorials directly in your browser.
+:::
+
 ### 2. Connect to Dash Platform
 
 Create a file named `connect.mjs` with the following contents. Then run it by typing `node connect.mjs` from the command line:
@@ -43,7 +47,7 @@ try {
 }
 ```
 
-Once this returns successfully, you're ready to begin developing! See the [Quickstart](../tutorials/introduction.md#quickstart) for recommended next steps. For details on SDK methods, please refer to the [SDK documentation](https://dashpay.github.io/evo-sdk-website/docs.html).
+Once this returns successfully, you're ready to begin developing! See the [Quickstart](../tutorials/introduction.md#quickstart) for recommended next steps. For details on SDK methods, please refer to the [SDK documentation](https://evo-sdk.dash.org/docs.html).
 
 ## Connect to a Local Devnet
 

--- a/docs/tutorials/example-apps.md
+++ b/docs/tutorials/example-apps.md
@@ -8,11 +8,50 @@ The tutorials in this section walk through complete, end-to-end applications bui
 
 Each app is a stand-alone project in the [`platform-tutorials/example-apps/`](https://github.com/dashpay/platform-tutorials/tree/main/example-apps) directory. The walkthroughs here tour the code alongside the commands needed to run it locally.
 
+::::{grid} 1 1 2 2
+:gutter: 3
+
+:::{grid-item-card} DashMint Lab
+:img-top: example-apps/img/dashmint-collection.png
+:class-card: example-app-card
+
+Explore a live NFT marketplace that demonstrates minting, transfers, pricing, purchases, burns,
+and token-powered document creation.
+
+```{button-link} https://dashpay.github.io/platform-tutorials/dashmint-lab/
+:color: primary
+:shadow:
+
+Try DashMint Lab live
+```
+
+[Read the walkthrough →](example-apps/dashmint-lab.md)
+:::
+
+:::{grid-item-card} Dashnote
+:img-top: example-apps/img/dashnote.png
+:class-card: example-app-card
+
+Try a complete mutable-document workflow with note creation, queries, editing, deletion, and
+read-only browsing.
+
+```{button-link} https://dashpay.github.io/platform-tutorials/dashnote/
+:color: primary
+:shadow:
+
+Try Dashnote live
+```
+
+[Read the walkthrough →](example-apps/dashnote.md)
+:::
+::::
+
 If you are looking for a focused snippet for one SDK call, the per-operation tutorials under [Identities and names](identities-and-names.md) and [Contracts and documents](contracts-and-documents.md) are a better starting point.
 
 ```{toctree}
 :maxdepth: 2
 :titlesonly:
+:hidden:
 
 example-apps/dashmint-lab
 example-apps/dashnote

--- a/docs/tutorials/example-apps/dashmint-lab.md
+++ b/docs/tutorials/example-apps/dashmint-lab.md
@@ -6,6 +6,13 @@
 
 [DashMint Lab](https://dashpay.github.io/platform-tutorials/dashmint-lab/) is a React + TypeScript + Vite single-page app that exercises every Dash Platform NFT operation: mint, transfer, price, purchase, burn, and query. Minting is gated by a fixed-supply DashMint token, so the walkthrough also shows how token balances, token transfers, and token-paid document creation fit into a real UI.
 
+```{button-link} https://dashpay.github.io/platform-tutorials/dashmint-lab/
+:color: primary
+:shadow:
+
+Try DashMint Lab live
+```
+
 ![DashMint Lab - Collection](./img/dashmint-collection.png)
 
 ## What this app does

--- a/docs/tutorials/example-apps/dashnote.md
+++ b/docs/tutorials/example-apps/dashnote.md
@@ -6,6 +6,13 @@
 
 [Dashnote](https://dashpay.github.io/platform-tutorials/dashnote/) is a React + TypeScript + Vite single-page app that demonstrates full mutable-document CRUD on Dash Platform. Users log in with a BIP-39 mnemonic, create notes with an optional title and required message body, edit and delete their own notes, and browse any identity's notes in read-only mode without credentials.
 
+```{button-link} https://dashpay.github.io/platform-tutorials/dashnote/
+:color: primary
+:shadow:
+
+Try Dashnote live
+```
+
 Where [DashMint Lab](dashmint-lab.md) covers the NFT-shaped operations (mint, transfer, price, purchase, burn), Dashnote covers the everyday document lifecycle: create, query, update, delete — plus the **fetch-then-bump-revision** pattern that every Platform document update has to follow.
 
 ![Dashnote](./img/dashnote.png)

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -32,7 +32,7 @@ While going through each tutorial is advantageous, the subset of tutorials liste
 
 ## Try it in the browser
 
-See the [Evo SDK site](https://evo-sdk.dash.org/) run queries against live networks, experiment with the [code playground](https://evo-sdk.dash.org/playground), or view [SDK documentation](https://evo-sdk.dash.org/docs.html) and an AI reference.
+Visit the [Evo SDK site](https://evo-sdk.dash.org/) to run queries against live networks, experiment with the [code playground](https://evo-sdk.dash.org/playground), or view [SDK documentation](https://evo-sdk.dash.org/docs.html) and an AI reference.
 
 ## Example apps
 

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -19,7 +19,7 @@ The tutorials in this section are written in JavaScript and use [Node.js](https:
 ## Quickstart
 
 :::{tip}
-You can clone a repository containing the code for all tutorials from <a href="https://github.com/dashpay/platform-readme-tutorials#readme" target="_blank">GitHub</a> or download it as a [zip file](https://github.com/dashpay/platform-readme-tutorials/archive/refs/heads/main.zip).
+You can clone a repository containing the code for all tutorials from <a href="https://github.com/dashpay/platform-readme-tutorials#readme" target="_blank">GitHub</a> or download it as a [zip file](https://github.com/dashpay/platform-readme-tutorials/archive/refs/heads/main.zip). Or, use the [Evo SDK playground](https://evo-sdk.dash.org/playground) to instantly experiment with tutorial queries -- no local setup required.
 :::
 
 While going through each tutorial is advantageous, the subset of tutorials listed below get you from a start to storing data on Dash Platform most quickly:
@@ -29,6 +29,10 @@ While going through each tutorial is advantageous, the subset of tutorials liste
 - [Registering an Identity](../tutorials/identities-and-names/register-an-identity.md)
 - [Registering a Data Contract](../tutorials/contracts-and-documents/register-a-data-contract.md)
 - [Submitting data](../tutorials/contracts-and-documents/submit-documents.md)
+
+## Try it in the browser
+
+See the [Evo SDK site](https://evo-sdk.dash.org/) run queries against live networks, experiment with the [code playground](https://evo-sdk.dash.org/playground), or view [SDK documentation](https://evo-sdk.dash.org/docs.html) and an AI reference.
 
 ## Example apps
 

--- a/docs/tutorials/setup-sdk-client.md
+++ b/docs/tutorials/setup-sdk-client.md
@@ -9,10 +9,12 @@ tutorials.
 
 ## Code
 
-Save the following two modules side-by-side — <a href="https://github.com/dashpay/platform-tutorials/blob/main/setupDashClient-core.mjs" target="_blank">setupDashClient-core.mjs</a> and
-<a href="https://github.com/dashpay/platform-tutorials/blob/main/setupDashClient.mjs" target="_blank">setupDashClient.mjs</a> — in the same directory. Later Node tutorials import from
-`setupDashClient.mjs`; browser apps can import from `setupDashClient-core.mjs`
-directly.
+Save the following two modules side-by-side — <a
+href="https://github.com/dashpay/platform-tutorials/blob/main/setupDashClient-core.mjs"
+target="_blank">setupDashClient-core.mjs</a> and <a
+href="https://github.com/dashpay/platform-tutorials/blob/main/setupDashClient.mjs"
+target="_blank">setupDashClient.mjs</a> — in the same directory. Later Node tutorials import from
+`setupDashClient.mjs`; browser apps can import from `setupDashClient-core.mjs` directly.
 
 :::{important}
 After saving, open `setupDashClient.mjs` (the wrapper) and set your mnemonic in


### PR DESCRIPTION
## Summary

Improves discoverability of the Evo SDK tooling and the example apps across the tutorials and resources sections.

## Changes

**Evo SDK references** — Point developers to the Evo SDK site (playground, docs, AI reference):
- Add a "Try it in the browser" section to the tutorials introduction and a playground tip on the connecting-to-testnet page.
- Add an Evo SDK site paragraph to the repository overview.
- Update the SDK documentation link to `evo-sdk.dash.org/docs.html` and reorder the Resources toctree.

**Example-app cards** — Give the example-apps index a visual entry point:
- Add a card grid with cropped screenshot previews and "try it live" buttons for DashMint Lab and Dashnote.
- Add matching live-demo buttons to each walkthrough page.
- Add CSS to crop/zoom the card screenshots and hide the now-redundant toctree.


<!-- Replace -->
Preview build: https://dash-docs-platform--158.org.readthedocs.build/en/158/
<!-- Replace -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-based Evo SDK Playground guidance for trying queries without local setup.
  * Added example app cards for DashMint Lab and Dashnote, with links to try each app live.
  * Enhanced example app previews with improved zooming and responsive sizing.

* **Documentation**
  * Updated resource links and SDK references across the documentation.
  * Added information about SDK tools, documentation, AI references, and live network access.
  * Improved setup instructions and example app navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->